### PR TITLE
feat: simplify any parameter, updated closures handling

### DIFF
--- a/Example/Mocky/ExampleProtocols.swift
+++ b/Example/Mocky/ExampleProtocols.swift
@@ -16,8 +16,30 @@ protocol UserStorageType {
 
 class UsersViewModel {
     var usersStorage: UserStorageType!
+    var userNetwork: UserNetworkType!
+
+    var id: String = "someid"
+    var error: Error?
+    var user: User?
 
     func saveUser(name: String, surname: String) {
         usersStorage.storeUser(name: name, surname: surname)
     }
+
+    func fetchUser() {
+        userNetwork.getUser(for: id) { user in
+            self.user = user
+        }
+    }
+}
+
+struct User {
+    let name: String
+}
+
+//sourcery: AutoMockable
+protocol UserNetworkType {
+    func getUser(for id: String, completion: (User?) -> Void)
+    func getUserEscaping(for id: String, completion: @escaping (User?,Error?) -> Void)
+    func doSomething(prop: @autoclosure () -> String)
 }

--- a/Example/Mocky/ExampleProtocols.swift
+++ b/Example/Mocky/ExampleProtocols.swift
@@ -26,9 +26,10 @@ class UsersViewModel {
         usersStorage.storeUser(name: name, surname: surname)
     }
 
-    func fetchUser() {
+    func fetchUser(completion: @escaping () -> Void) {
         userNetwork.getUser(for: id) { user in
             self.user = user
+            completion()
         }
     }
 }

--- a/Example/Tests/Mocks/Mock.generated.swift
+++ b/Example/Tests/Mocks/Mock.generated.swift
@@ -86,8 +86,8 @@ class ComplicatedServiceTypeMock: ComplicatedServiceType, Mock {
       }
       
       func methodWithClosures(success function: LinearFunction) -> ClosureFabric {
-          addInvocation(.methodWithClosures__success_function_1(.value(function)))
-          	let perform = methodPerformValue(.methodWithClosures__success_function_1(.value(function))) as? (LinearFunction) -> Void
+          addInvocation(.methodWithClosures__success_function_1(Parameter<LinearFunction>.any))
+          	let perform = methodPerformValue(.methodWithClosures__success_function_1(Parameter<LinearFunction>.any)) as? (LinearFunction) -> Void
 			perform?(function)
           return methodReturnValue(.methodWithClosures__success_function_1(.value(function))) as! ClosureFabric 
       }
@@ -853,8 +853,8 @@ class SampleServiceTypeMock: SampleServiceType, Mock {
       }
       
       func methodWithClosures(success function: LinearFunction) -> ClosureFabric {
-          addInvocation(.methodWithClosures__success_function_1(.value(function)))
-          	let perform = methodPerformValue(.methodWithClosures__success_function_1(.value(function))) as? (LinearFunction) -> Void
+          addInvocation(.methodWithClosures__success_function_1(Parameter<LinearFunction>.any))
+          	let perform = methodPerformValue(.methodWithClosures__success_function_1(Parameter<LinearFunction>.any)) as? (LinearFunction) -> Void
 			perform?(function)
           return methodReturnValue(.methodWithClosures__success_function_1(.value(function))) as! ClosureFabric 
       }
@@ -1142,6 +1142,157 @@ class SimpleServiceTypeMock: SimpleServiceType, Mock {
 
           static func serviceName(perform: () -> Void) -> PerformProxy {
               return PerformProxy(method: .serviceName, performs: perform)
+          }
+        }
+
+      public func matchingCalls(_ method: VerificationProxy) -> Int {
+          return matchingCalls(method.method).count
+      }
+
+      public func given(_ method: MethodProxy) {
+          methodReturnValues.append(method)
+          methodReturnValues.sort { $0.method.intValue() < $1.method.intValue() }
+      }
+
+      public func perform(_ method: PerformProxy) {
+          methodPerformValues.append(method)
+          methodPerformValues.sort { $0.method.intValue() < $1.method.intValue() }
+      }
+
+      public func verify(_ method: VerificationProxy, count: UInt = 1, file: StaticString = #file, line: UInt = #line) {
+          let method = method.method
+          let invocations = matchingCalls(method)
+          XCTAssert(invocations.count == Int(count), "Expeced: \(count) invocations of `\(method)`, but was: \(invocations.count)", file: file, line: line)
+      }
+
+      private func addInvocation(_ call: MethodType) {
+          invocations.append(call)
+      }
+
+      private func methodReturnValue(_ method: MethodType) -> Any? {
+          let matched = methodReturnValues.reversed().first(where: { proxy -> Bool in
+              return MethodType.compareParameters(lhs: proxy.method, rhs: method, matcher: matcher)
+          })
+
+          return matched?.returns
+      }
+
+      private func methodPerformValue(_ method: MethodType) -> Any? {
+          let matched = methodPerformValues.reversed().first(where: { proxy -> Bool in
+              return MethodType.compareParameters(lhs: proxy.method, rhs: method, matcher: matcher)
+          })
+
+          return matched?.performs
+      }
+
+      private func matchingCalls(_ method: MethodType) -> [MethodType] {
+          let matchingInvocations = invocations.filter({ (call) -> Bool in
+              return MethodType.compareParameters(lhs: call, rhs: method, matcher: matcher)
+          })
+          return matchingInvocations
+      }
+}
+
+// MARK: - UserNetworkType
+class UserNetworkTypeMock: UserNetworkType, Mock {
+
+      fileprivate var invocations: [MethodType] = []
+      var methodReturnValues: [MethodProxy] = []
+      var methodPerformValues: [PerformProxy] = []
+      var matcher: Matcher = Matcher.default
+            
+            
+
+      func getUser(for id: String, completion: (User?) -> Void) {
+          addInvocation(.getUser__for_idcompletion_completion(.value(id), Parameter<(User?) -> Void>.any))
+          	let perform = methodPerformValue(.getUser__for_idcompletion_completion(.value(id), Parameter<(User?) -> Void>.any)) as? (String, (User?) -> Void) -> Void
+			perform?(id, completion)
+          
+      }
+      
+      func getUserEscaping(for id: String, completion: @escaping (User?,Error?) -> Void) {
+          addInvocation(.getUserEscaping__for_idcompletion_completion(.value(id), .value(completion)))
+          	let perform = methodPerformValue(.getUserEscaping__for_idcompletion_completion(.value(id), .value(completion))) as? (String, @escaping (User?,Error?) -> Void) -> Void
+			perform?(id, completion)
+          
+      }
+      
+      func doSomething(prop: @autoclosure () -> String) {
+          addInvocation(.doSomething__prop_prop(Parameter< () -> String>.any))
+          	let perform = methodPerformValue(.doSomething__prop_prop(Parameter< () -> String>.any)) as? (@autoclosure () -> String) -> Void
+			perform?(prop)
+          
+      }
+      
+      fileprivate enum MethodType {
+
+          case getUser__for_idcompletion_completion(Parameter<String>, Parameter<(User?) -> Void>)      
+          case getUserEscaping__for_idcompletion_completion(Parameter<String>, Parameter< (User?,Error?) -> Void>)      
+          case doSomething__prop_prop(Parameter< () -> String>)      
+
+
+          static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Bool {
+              switch (lhs, rhs) {
+                  case (.getUser__for_idcompletion_completion(let lhsId, let lhsCompletion), .getUser__for_idcompletion_completion(let rhsId, let rhsCompletion)): 
+                      guard Parameter.compare(lhs: lhsId, rhs: rhsId, with: matcher) else { return false } 
+                      guard Parameter.compare(lhs: lhsCompletion, rhs: rhsCompletion, with: matcher) else { return false } 
+                      return true 
+                  case (.getUserEscaping__for_idcompletion_completion(let lhsId, let lhsCompletion), .getUserEscaping__for_idcompletion_completion(let rhsId, let rhsCompletion)): 
+                      guard Parameter.compare(lhs: lhsId, rhs: rhsId, with: matcher) else { return false } 
+                      guard Parameter.compare(lhs: lhsCompletion, rhs: rhsCompletion, with: matcher) else { return false } 
+                      return true 
+                  case (.doSomething__prop_prop(let lhsProp), .doSomething__prop_prop(let rhsProp)): 
+                      guard Parameter.compare(lhs: lhsProp, rhs: rhsProp, with: matcher) else { return false } 
+                      return true 
+                  default: return false
+              }
+          }
+
+          func intValue() -> Int {
+              switch self {
+                  case let .getUser__for_idcompletion_completion(p0, p1): return p0.intValue + p1.intValue
+                  case let .getUserEscaping__for_idcompletion_completion(p0, p1): return p0.intValue + p1.intValue
+                  case let .doSomething__prop_prop(p0): return p0.intValue
+              }
+          }
+      }
+
+      struct MethodProxy {
+          fileprivate var method: MethodType
+          var returns: Any?
+      }
+
+      struct VerificationProxy {
+          fileprivate var method: MethodType
+
+
+          static func getUser(for id: Parameter<String>, completion: Parameter<(User?) -> Void>) -> VerificationProxy {
+              return VerificationProxy(method: .getUser__for_idcompletion_completion(id, completion))
+          }
+  
+          static func getUserEscaping(for id: Parameter<String>, completion: Parameter< (User?,Error?) -> Void>) -> VerificationProxy {
+              return VerificationProxy(method: .getUserEscaping__for_idcompletion_completion(id, completion))
+          }
+  
+          static func doSomething(prop: Parameter< () -> String>) -> VerificationProxy {
+              return VerificationProxy(method: .doSomething__prop_prop(prop))
+          }
+        }
+
+      struct PerformProxy {
+          fileprivate var method: MethodType
+          var performs: Any
+
+          static func getUser(for id: Parameter<String>, completion: Parameter<(User?) -> Void>, perform: (String, (User?) -> Void) -> Void) -> PerformProxy {
+              return PerformProxy(method: .getUser__for_idcompletion_completion(id, completion), performs: perform)
+          }
+  
+          static func getUserEscaping(for id: Parameter<String>, completion: Parameter< (User?,Error?) -> Void>, perform: (String, @escaping (User?,Error?) -> Void) -> Void) -> PerformProxy {
+              return PerformProxy(method: .getUserEscaping__for_idcompletion_completion(id, completion), performs: perform)
+          }
+  
+          static func doSomething(prop: Parameter< () -> String>, perform: (@autoclosure () -> String) -> Void) -> PerformProxy {
+              return PerformProxy(method: .doSomething__prop_prop(prop), performs: perform)
           }
         }
 

--- a/Example/Tests/XCTests/ComplicatedServiceTests.swift
+++ b/Example/Tests/XCTests/ComplicatedServiceTests.swift
@@ -48,4 +48,22 @@ class ComplicatedServiceTests: XCTestCase {
         XCTAssertEqual(second.x, 1)
         XCTAssertEqual(second.y, 1)
     }
+
+    func test_closures() {
+        var calls = 0
+
+        service.given(.methodWithClosures(success: Parameter<((Scalar, Scalar) -> Scalar)?>.any, willReturn: { _ in }))
+
+        service.perform(.methodWithClosures(success: Parameter<((Scalar, Scalar) -> Scalar)?>.any,
+                                            perform: { function in
+            _ = function?(Scalar(1),Scalar(2))
+        }))
+
+        _ = service.methodWithClosures { (a, b) -> Scalar in
+            calls += 1
+            return a + b
+        }
+
+        XCTAssertEqual(calls, 1)
+    }
 }

--- a/Example/Tests/XCTests/ExampleTests.swift
+++ b/Example/Tests/XCTests/ExampleTests.swift
@@ -15,7 +15,7 @@ class ExampleTests: XCTestCase {
         let mock = UserStorageTypeMock()
 
         Given(mock, .surname(for: .value("Johny"), willReturn: "Bravo"))
-        Given(mock, .surname(for: .any(String.self), willReturn: "Kowalsky"))
+        Given(mock, .surname(for: .any, willReturn: "Kowalsky"))
 
         var joannas = 0
         Perform(mock, .surname(for: Parameter<String>.value("Joanna"), perform: { (value) in
@@ -24,7 +24,7 @@ class ExampleTests: XCTestCase {
         }))
 
         var others = 0
-        Perform(mock, .surname(for: Parameter<String>.any(String.self), perform: { (value) in
+        Perform(mock, .surname(for: .any, perform: { (value) in
             print("\(value) should be different to Joanna")
             others += 1
         }))
@@ -49,8 +49,18 @@ class ExampleTests: XCTestCase {
         // check is Jon Snow was stored at least one time
         Verify(mockStorage, .storeUser(name: .value("Jon"), surname: .value("Snow")))
         // total storeUser should be triggered 3 times, regardless of attributes values
-        Verify(mockStorage, 3, .storeUser(name: .any(String.self), surname: .any(String.self)))
+        Verify(mockStorage, 3, .storeUser(name: .any, surname: .any))
         // two times it should be triggered with name Johny
-        Verify(mockStorage, 2, .storeUser(name: .value("Johny"), surname: .any(String.self)))
+        Verify(mockStorage, 2, .storeUser(name: .value("Johny"), surname: .any))
+    }
+
+    func test_completionBlocksBasedApproach() {
+        let sut = UsersViewModel()
+        let mock = UserNetworkTypeMock()
+        sut.userNetwork = mock
+
+        Perform(mock, .getUser(for: .any, completion: .any, perform: { id, completion in
+            
+        }))
     }
 }

--- a/Example/Tests/XCTests/ExampleTests.swift
+++ b/Example/Tests/XCTests/ExampleTests.swift
@@ -18,7 +18,7 @@ class ExampleTests: XCTestCase {
         Given(mock, .surname(for: .any, willReturn: "Kowalsky"))
 
         var joannas = 0
-        Perform(mock, .surname(for: Parameter<String>.value("Joanna"), perform: { (value) in
+        Perform(mock, .surname(for: .value("Joanna"), perform: { (value) in
             print("\(value) should be Joanna")
             joannas += 1
         }))
@@ -55,12 +55,26 @@ class ExampleTests: XCTestCase {
     }
 
     func test_completionBlocksBasedApproach() {
+        let user = User(name: "Barabasz")
         let sut = UsersViewModel()
         let mock = UserNetworkTypeMock()
         sut.userNetwork = mock
 
         Perform(mock, .getUser(for: .any, completion: .any, perform: { id, completion in
-            
+            completion(user)
         }))
+
+        let fetchExpectation = expectation(description: "Should call completion block after done")
+
+        sut.fetchUser() {
+            fetchExpectation.fulfill()
+            XCTAssertNotNil(sut.user)
+        }
+
+        waitForExpectations(timeout: 1) { (error) in
+            if let error = error {
+                XCTFail("Fetch user failed woth error: \(error)")
+            }
+        }
     }
 }

--- a/Example/Tests/XCTests/ItemsModelTests.swift
+++ b/Example/Tests/XCTests/ItemsModelTests.swift
@@ -73,7 +73,7 @@ class ItemsModelTests: XCTestCase {
         let details = ItemDetails(item: item, price: 0, description: ["desc": "value"])
 
         itemsRepositoryMock.given(.storedDetails(item: .value(item), willReturn: nil))
-        itemsClientMock.given(.getItemDetails(item: .any(Item.self), willReturn: Observable.just(details)))
+        itemsClientMock.given(.getItemDetails(item: .any, willReturn: Observable.just(details)))
 
         let reveivedDetails = try! sut.getItemDetails(item: item).toBlocking().single()!
 
@@ -87,7 +87,7 @@ class ItemsModelTests: XCTestCase {
         let item = Item(name: "itemName", id: 0)
         let details = ItemDetails(item: item, price: 0, description: ["desc": "value"])
 
-        itemsRepositoryMock.given(.storedDetails(item: .any(Item.self), willReturn: details))
+        itemsRepositoryMock.given(.storedDetails(item: .any, willReturn: details))
 
         let reveivedDetails = try! sut.getItemDetails(item: item).toBlocking().single()!
 

--- a/Mocky/Classes/Parameter.swift
+++ b/Mocky/Classes/Parameter.swift
@@ -9,27 +9,32 @@
 import Foundation
 
 /// Parameter wraps method attribute, allowing to make a difference between explicit value,
-/// expressed by .value case and wildcard value, expressed by .any case.
+/// expressed by .value case and wildcard value, expressed by ._ case.
 ///
 /// That allows pattern like matching between two Parameter values:
-/// - **.any** is equal to every other parameter
+/// - **._** is equal to every other parameter
 /// - **.value(p1)** is equal to **.value(p2)** only, when p1 == p2
 ///
 /// **Important!** Comparing parameters, where ValueType is not Equatable will result in fatalError,
 /// unless you register comparator for its *ValueType* in **Matcher** instance used (typically Matcher.default)
 ///
-/// - any: represents and matches any parameter value
+/// - _: represents and matches any parameter value
 /// - value: represents explicit parameter value
 public enum Parameter<ValueType> {
-    case any(ValueType.Type)
+    case `_`
     case value(ValueType)
+
+    public static var any: Parameter<ValueType> { return Parameter<ValueType>._ }
+    public static func any<T>(_ type: T.Type) -> Parameter<T> {
+        return Parameter<T>._
+    }
 }
 
 // MARK: - Order
 public extension Parameter {
     public var intValue: Int {
         switch self {
-            case .any: return 0
+            case ._: return 0
             case .value: return 1
         }
     }
@@ -43,8 +48,8 @@ public extension Parameter {
 
     public static func compare(lhs: Parameter<ValueType>, rhs: Parameter<ValueType>, with matcher: Matcher) -> Bool {
         switch (lhs, rhs) {
-        case (.any, _): return true
-        case (_, .any): return true
+        case (._, _): return true
+        case (_, ._): return true
         case (.value(let lhsValue), .value(let rhsValue)):
             guard let compare = matcher.comparator(for: ValueType.self) else {
                 fatalError("No registered comparators for \(String(describing: ValueType.self))")
@@ -58,8 +63,8 @@ public extension Parameter {
 public extension Parameter where ValueType: Equatable {
     public static func ==(lhs: Parameter<ValueType>, rhs: Parameter<ValueType>) -> Bool {
         switch (lhs, rhs) {
-        case (.any, _): return true
-        case (_, .any): return true
+        case (._, _): return true
+        case (_, ._): return true
         case (.value(let value1), .value(let value2)):
             return value1 == value2
         default: return false
@@ -74,8 +79,8 @@ public extension Parameter where ValueType: Equatable {
 public extension Parameter where ValueType: Sequence {
     public static func compare(lhs: Parameter<ValueType>, rhs: Parameter<ValueType>, with matcher: Matcher) -> Bool {
         switch (lhs, rhs) {
-        case (.any, _): return true
-        case (_, .any): return true
+        case (._, _): return true
+        case (_, ._): return true
         case (.value(let lhsSequence), .value(let rhsSequence)):
             let leftArray = lhsSequence.map { $0 }
             let rightArray = rhsSequence.map { $0 }
@@ -106,8 +111,8 @@ public extension Parameter where ValueType: Sequence {
 public extension Parameter where ValueType: Sequence, ValueType.Element: Equatable {
     public static func compare(lhs: Parameter<ValueType>, rhs: Parameter<ValueType>, with matcher: Matcher) -> Bool {
         switch (lhs, rhs) {
-        case (.any, _): return true
-        case (_, .any): return true
+        case (._, _): return true
+        case (_, ._): return true
         case (.value(let lhsSequence), .value(let rhsSequence)):
             let leftArray = lhsSequence.map { $0 }
             let rightArray = rhsSequence.map { $0 }
@@ -132,8 +137,8 @@ public extension Parameter where ValueType: Sequence, ValueType.Element: Equatab
 public extension Parameter where ValueType: Sequence, ValueType.Element: Equatable, ValueType: Equatable {
     public static func ==(lhs: Parameter<ValueType>, rhs: Parameter<ValueType>) -> Bool {
         switch (lhs, rhs) {
-        case (.any, _): return true
-        case (_, .any): return true
+        case (._, _): return true
+        case (_, ._): return true
         case (.value(let lhsSequence), .value(let rhsSequence)):
             return lhsSequence == rhsSequence
         default: return false

--- a/Mocky/Classes/Parameter.swift
+++ b/Mocky/Classes/Parameter.swift
@@ -30,10 +30,6 @@ public enum Parameter<ValueType> {
     }
 }
 
-public func any<T>() -> Parameter<T> {
-    return Parameter<T>.any(T.self)
-}
-
 // MARK: - Order
 public extension Parameter {
     public var intValue: Int {

--- a/Mocky/Templates/Mock.swifttemplate
+++ b/Mocky/Templates/Mock.swifttemplate
@@ -176,7 +176,17 @@ class MethodWrapper {
         if method.parameters.isEmpty {
             return "addInvocation(.\(prototype))"
         } else {
-            let parameters = method.parameters.map { ".value(\($0.name))" }.joined(separator: ", ")
+            let parameters = method.parameters.map { param in
+              let typeString = "\(param.actualTypeName ?? param.typeName)"
+              let isEscaping = typeString.contains("@escaping")
+              let isOptional = (param.actualTypeName ?? param.typeName).isOptional
+              if param.isClosure, !isEscaping, !isOptional {
+                let type = strip("\(param.typeName)")
+                return "Parameter<\(type)>.any"
+              } else {
+                return ".value(\(param.name))"
+              }
+            }.joined(separator: ", ")
             return "addInvocation(.\(prototype)(\(parameters)))"
         }
     }
@@ -230,11 +240,9 @@ class MethodWrapper {
         if let count = MethodWrapper.registered[name] {
             MethodWrapper.registered[name] = count + 1
             MethodWrapper.suffixes[uniqueName] = count + 1
-            // print("registered \(name) with \(count + 1)")
         } else {
             MethodWrapper.registered[name] = 1
             MethodWrapper.suffixes[uniqueName] = 1
-            // print("registered \(name) with \(1)")
         }
 
         return ""
@@ -245,7 +253,7 @@ class MethodWrapper {
             return method.shortName
         }
         let parameters = method.parameters
-        .map {  return "Parameter<\($0.typeName.name)>" }
+        .map {  return "Parameter<\(strip($0.typeName.name))>" }
         .joined(separator: ", ")
         .replacingOccurrences(of: "@escaping", with: "")
         return "\(prototype)(\(parameters))"
@@ -256,15 +264,16 @@ class MethodWrapper {
             return "static func \(method.shortName)(willReturn: \(method.returnTypeName)) -> MethodProxy"
         } else {
             let functionParameters = method.parameters.map {
+                let paramType = strip("\($0.typeName)")
                 guard let argumentLabel = $0.argumentLabel else {
-                    return "\($0.name): Parameter<\($0.typeName)>"
+                    return "\($0.name): Parameter<\(paramType)>"
                 }
 
                 guard argumentLabel != $0.name else {
-                    return "\($0.name): Parameter<\($0.typeName)>"
+                    return "\($0.name): Parameter<\(paramType)>"
                 }
 
-                return "\(argumentLabel) \($0.name): Parameter<\($0.typeName)>"
+                return "\(argumentLabel) \($0.name): Parameter<\(paramType)>"
             }.joined(separator: ", ")
             return "static func \(method.shortName)(\(functionParameters), willReturn: \(method.returnTypeName)) -> MethodProxy"
         }
@@ -284,15 +293,16 @@ class MethodWrapper {
             return "static func \(method.shortName)() -> VerificationProxy"
         } else {
             let functionParameters = method.parameters.map {
+                let paramType = strip("\($0.typeName)")
                 guard let argumentLabel = $0.argumentLabel else {
-                    return "\($0.name): Parameter<\($0.typeName)>"
+                    return "\($0.name): Parameter<\(paramType)>"
                 }
 
                 guard argumentLabel != $0.name else {
-                    return "\($0.name): Parameter<\($0.typeName)>"
+                    return "\($0.name): Parameter<\(paramType)>"
                 }
 
-                return "\(argumentLabel) \($0.name): Parameter<\($0.typeName)>"
+                return "\(argumentLabel) \($0.name): Parameter<\(paramType)>"
             }.joined(separator: ", ")
             return "static func \(method.shortName)(\(functionParameters)) -> VerificationProxy"
         }
@@ -312,15 +322,16 @@ class MethodWrapper {
             return "static func \(method.shortName)(perform: \(performProxyClosureType())) -> PerformProxy"
         } else {
             let functionParameters = method.parameters.map {
+                let paramType = strip("\($0.typeName)")
                 guard let argumentLabel = $0.argumentLabel else {
-                    return "\($0.name): Parameter<\($0.typeName)>"
+                    return "\($0.name): Parameter<\(paramType)>"
                 }
 
                 guard argumentLabel != $0.name else {
-                    return "\($0.name): Parameter<\($0.typeName)>"
+                    return "\($0.name): Parameter<\(paramType)>"
                 }
 
-                return "\(argumentLabel) \($0.name): Parameter<\($0.typeName)>"
+                return "\(argumentLabel) \($0.name): Parameter<\(paramType)>"
             }.joined(separator: ", ")
             return "static func \(method.shortName)(\(functionParameters), perform: \(performProxyClosureType())) -> PerformProxy"
         }
@@ -339,7 +350,9 @@ class MethodWrapper {
         if method.parameters.isEmpty {
             return "() -> Void"
         } else {
-            let parameters = method.parameters.map { "\($0.typeName)" }.joined(separator: ", ")
+            let parameters = method.parameters
+            .map { "\($0.typeName)" }
+            .joined(separator: ", ")
             return "(\(parameters)) -> Void"
         }
     }
@@ -360,7 +373,17 @@ class MethodWrapper {
         if method.parameters.isEmpty {
             proxy = "\(prototype)"
         } else {
-            let parameters = method.parameters.map { ".value(\($0.name))" }.joined(separator: ", ")
+            let parameters = method.parameters.map { param in
+              let typeString = "\(param.actualTypeName ?? param.typeName)"
+              let isEscaping = typeString.contains("@escaping")
+              let isOptional = (param.actualTypeName ?? param.typeName).isOptional
+              if param.isClosure, !isEscaping, !isOptional {
+                let type = strip("\(param.typeName)")
+                return "Parameter<\(type)>.any"
+              } else {
+                return ".value(\(param.name))"
+              }
+            }.joined(separator: ", ")
             proxy = "\(prototype)(\(parameters))"
         }
 
@@ -368,6 +391,10 @@ class MethodWrapper {
         let call = performProxyClosureCall()
 
         return "\t\(cast)\n\t\t\t\(call)"
+    }
+
+    private func strip(_ type: String) -> String {
+        return type.replacingOccurrences(of: "@escaping", with: "").replacingOccurrences(of: "@autoclosure", with: "")
     }
 }
 


### PR DESCRIPTION
Parameter:
 + added static var and fun, allowing to init param with .any and .any(Type.self)
 + renamed any case to `_` (because of naming conflicts)

Other:
 + base handling of @escaping closures
 + base handling od @autoclosure