### PR TITLE
feat: added basic support for protocol initialisers

### DIFF
--- a/Example/Mocky/ExampleProtocols.swift
+++ b/Example/Mocky/ExampleProtocols.swift
@@ -38,8 +38,15 @@ struct User {
     let name: String
 }
 
+struct NetworkConfig {
+    let baseUrl: String
+}
+
 //sourcery: AutoMockable
 protocol UserNetworkType {
+    init(config: NetworkConfig)
+    init(baseUrl: String)
+
     func getUser(for id: String, completion: (User?) -> Void)
     func getUserEscaping(for id: String, completion: @escaping (User?,Error?) -> Void)
     func doSomething(prop: @autoclosure () -> String)

--- a/Example/Tests/Mocks/Mock.generated.swift
+++ b/Example/Tests/Mocks/Mock.generated.swift
@@ -1203,6 +1203,18 @@ class UserNetworkTypeMock: UserNetworkType, Mock {
             
             
 
+      required init(config: NetworkConfig) {
+          
+          
+          
+      }
+      
+      required init(baseUrl: String) {
+          
+          
+          
+      }
+      
       func getUser(for id: String, completion: (User?) -> Void) {
           addInvocation(.getUser__for_idcompletion_completion(.value(id), Parameter<(User?) -> Void>.any))
           	let perform = methodPerformValue(.getUser__for_idcompletion_completion(.value(id), Parameter<(User?) -> Void>.any)) as? (String, (User?) -> Void) -> Void

--- a/Example/Tests/XCTests/ExampleTests.swift
+++ b/Example/Tests/XCTests/ExampleTests.swift
@@ -57,7 +57,7 @@ class ExampleTests: XCTestCase {
     func test_completionBlocksBasedApproach() {
         let user = User(name: "Barabasz")
         let sut = UsersViewModel()
-        let mock = UserNetworkTypeMock()
+        let mock = UserNetworkTypeMock(baseUrl: "http://someurl")
         sut.userNetwork = mock
 
         Perform(mock, .getUser(for: .any, completion: .any, perform: { id, completion in

--- a/Mock.generated.swift
+++ b/Mock.generated.swift
@@ -1,5 +1,0 @@
-// Generated using Sourcery 0.6.0 — https://github.com/krzysztofzablocki/Sourcery
-// DO NOT EDIT
-
-STATUS:
-Skipping Mock.generated.swift as it is empty.

--- a/Mocky/Templates/Mock.swifttemplate
+++ b/Mocky/Templates/Mock.swifttemplate
@@ -154,25 +154,23 @@ class MethodWrapper {
     }
 
     var prototype: String {
-        get {
-          return "\(registrationName)\(nameSuffix)"
-        }
+        return "\(registrationName)\(nameSuffix)"
     }
     var parameters: [ParameterWrapper] {
-        get {
-            return method.parameters.map { ParameterWrapper($0) }
-        }
+        return method.parameters.map { ParameterWrapper($0) }
     }
     var functionPrototype: String {
-        get {
-            if method.returnTypeName.isVoid {
-                return "func \(method.name) "
-            } else {
-                return "func \(method.name) -> \(method.returnTypeName.name) "
-            }
+        if method.isInitializer {
+            return "required \(method.name) "
+        }
+        else if method.returnTypeName.isVoid {
+            return "func \(method.name) "
+        } else {
+            return "func \(method.name) -> \(method.returnTypeName.name) "
         }
     }
     var invocation: String {
+        guard !method.isInitializer else { return "" }
         if method.parameters.isEmpty {
             return "addInvocation(.\(prototype))"
         } else {
@@ -191,6 +189,7 @@ class MethodWrapper {
         }
     }
     var returnValue: String {
+        guard !method.isInitializer else { return "" }
         guard !method.returnTypeName.isVoid else { return "" }
         if method.parameters.isEmpty {
             return "return methodReturnValue(.\(prototype)) as! \(method.returnTypeName) "
@@ -200,28 +199,25 @@ class MethodWrapper {
         }
     }
     var equalCase: String {
-        get {
-            if method.parameters.isEmpty {
-                return "case (.\(prototype), .\(prototype)):"
-            } else {
-                let lhsParams = method.parameters.map { "let lhs\($0.name.capitalized)" }.joined(separator: ", ")
-                let rhsParams = method.parameters.map { "let rhs\($0.name.capitalized)" }.joined(separator: ", ")
-                return "case (.\(prototype)(\(lhsParams)), .\(prototype)(\(rhsParams))):"
-            }
+        guard !method.isInitializer else { return "" }
+        if method.parameters.isEmpty {
+            return "case (.\(prototype), .\(prototype)):"
+        } else {
+            let lhsParams = method.parameters.map { "let lhs\($0.name.capitalized)" }.joined(separator: ", ")
+            let rhsParams = method.parameters.map { "let rhs\($0.name.capitalized)" }.joined(separator: ", ")
+            return "case (.\(prototype)(\(lhsParams)), .\(prototype)(\(rhsParams))):"
         }
     }
     var intValueCase: String {
-        get {
-            if method.parameters.isEmpty {
-                return "case .\(prototype): return 0"
-            } else {
-                let params = method.parameters.enumerated().map { offset, _ in
-                    return "p\(offset)"
-                }
-                let definitions = params.joined(separator: ", ")
-                let paramsSum = params.map({ "\($0).intValue" }).joined(separator: " + ")
-                return "case let .\(prototype)(\(definitions)): return \(paramsSum)"
+        if method.parameters.isEmpty {
+            return "case .\(prototype): return 0"
+        } else {
+            let params = method.parameters.enumerated().map { offset, _ in
+                return "p\(offset)"
             }
+            let definitions = params.joined(separator: ", ")
+            let paramsSum = params.map({ "\($0).intValue" }).joined(separator: " + ")
+            return "case let .\(prototype)(\(definitions)): return \(paramsSum)"
         }
     }
 
@@ -257,6 +253,10 @@ class MethodWrapper {
         .joined(separator: ", ")
         .replacingOccurrences(of: "@escaping", with: "")
         return "\(prototype)(\(parameters))"
+    }
+
+    func wrappedInMethodType() -> Bool {
+        return !method.isInitializer
     }
 
     func proxyConstructorName() -> String {
@@ -367,6 +367,7 @@ class MethodWrapper {
     }
 
     func performCall() -> String {
+        guard !method.isInitializer else { return "" }
         let type = performProxyClosureType()
         var proxy = ""
 
@@ -434,7 +435,7 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
       <% } %> <%_ -%>
       <%_ -%>
       <% MethodWrapper.clear() -%>
-      <% for method in allMethods.map(wrapMethod) { method.register() } -%>
+      <% for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { method.register() } -%>
 
       <%_ for method in allMethods.map(wrapMethod) { %>
       <%= method.functionPrototype _%> {
@@ -445,13 +446,13 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
       <%  } %> <%_ -%>
 
       fileprivate enum MethodType {
-      <%_ for method in allMethods.map(wrapMethod) { _%>
+      <%_ for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { _%>
           case <%= method.methodDeclarationWithParameters() -%>
       <%  } %>
       <%_ %>
 
           static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Bool {
-              switch (lhs, rhs) { <%_ for method in allMethods.map(wrapMethod) { %>
+              switch (lhs, rhs) { <%_ for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { %>
                   <%= method.equalCase -%> <% for parameter in method.parameters { %>
                       <%= parameter.comparator -%> <%  } %>
                       return true <% } %>
@@ -461,7 +462,7 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
           }
       <%_ %>
           func intValue() -> Int {
-              switch self { <%_ for method in allMethods.map(wrapMethod) { %>
+              switch self { <%_ for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { %>
                   <%= method.intValueCase -%><% } %>
               }
           }
@@ -470,7 +471,7 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
       struct MethodProxy {
           fileprivate var method: MethodType
           var returns: Any?
-          <%_ for method in allMethods.filter({ !$0.returnTypeName.isVoid }).map(wrapMethod) { %>
+          <%_ for method in allMethods.filter({ !$0.returnTypeName.isVoid && !$0.isInitializer }).map(wrapMethod) { %>
           <%= method.proxyConstructorName() -%> {
               <%= method.proxyConstructor() _%>
           }
@@ -480,7 +481,7 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
       struct VerificationProxy {
           fileprivate var method: MethodType
 
-          <%_ for method in allMethods.map(wrapMethod) { %>
+          <%_ for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { %>
           <%= method.verificationProxyConstructorName() -%> {
               <%= method.verificationProxyConstructor() _%>
           }
@@ -490,7 +491,7 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
       struct PerformProxy {
           fileprivate var method: MethodType
           var performs: Any
-          <%_ for method in allMethods.map(wrapMethod) { %>
+          <%_ for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { %>
           <%= method.performProxyConstructorName() -%> {
               <%= method.performProxyConstructor() _%>
           }
@@ -572,7 +573,7 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
     <% } %> <%_ -%>
     <%_ -%>
     <% MethodWrapper.clear() -%>
-    <% for method in allMethods.map(wrapMethod) { method.register() } -%>
+    <% for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { method.register() } -%>
 
     <%_ for method in allMethods.map(wrapMethod) { %>
     <%= method.functionPrototype _%> {
@@ -583,13 +584,13 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
     <%  } %> <%_ -%>
 
     fileprivate enum MethodType {
-    <%_ for method in allMethods.map(wrapMethod) { _%>
+    <%_ for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { _%>
         case <%= method.methodDeclarationWithParameters() -%>
     <%  } %>
     <%_ -%>
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Bool {
             switch (lhs, rhs) {
-             <%_ for method in allMethods.map(wrapMethod) { %>
+             <%_ for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { %>
                 <%= method.equalCase -%> <% for parameter in method.parameters { %>
                     <%= parameter.comparator -%> <%  } %>
                     return true <% } %>
@@ -599,7 +600,7 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
         }
     <%_ %>
         func intValue() -> Int {
-            switch self { <%_ for method in allMethods.map(wrapMethod) { %>
+            switch self { <%_ for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { %>
                 <%= method.intValueCase -%><% } %>
             }
         }
@@ -608,7 +609,7 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
     struct MethodProxy {
         fileprivate var method: MethodType
         var returns: Any?
-        <%_ for method in allMethods.filter({ !$0.returnTypeName.isVoid }).map(wrapMethod) { %>
+        <%_ for method in allMethods.filter({ !$0.returnTypeName.isVoid && !$0.isInitializer }).map(wrapMethod) { %>
         <%= method.proxyConstructorName() -%> {
             <%= method.proxyConstructor() _%>
         }
@@ -618,7 +619,7 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
     struct VerificationProxy {
         fileprivate var method: MethodType
 
-        <%_ for method in allMethods.map(wrapMethod) { %>
+        <%_ for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { %>
         <%= method.verificationProxyConstructorName() -%> {
             <%= method.verificationProxyConstructor() _%>
         }
@@ -628,7 +629,7 @@ class <%= type.name %>Mock:<%= type.annotations["ObjcProtocol"] != nil ? " NSObj
     struct PerformProxy {
         fileprivate var method: MethodType
         var performs: Any
-        <%_ for method in allMethods.map(wrapMethod) { %>
+        <%_ for method in allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) { %>
         <%= method.performProxyConstructorName() -%> {
             <%= method.performProxyConstructor() _%>
         }


### PR DESCRIPTION
We should show method (required init) definitions, but as for now I decided not to handle given (for bailable initialisers) / verify / perform. It makes little sense at this point.