### PR TITLE
fix: matcher and parameter conditional compile for swift 3.1

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,9 +3,9 @@ PODS:
     - RxSwift (~> 4.0)
   - RxSwift (4.0.0)
   - Sourcery (0.9.0)
-  - SwiftyMocky (0.9.0):
-    - SwiftyMocky/Core (= 0.9.0)
-  - SwiftyMocky/Core (0.9.0):
+  - SwiftyMocky (1.0.1):
+    - SwiftyMocky/Core (= 1.0.1)
+  - SwiftyMocky/Core (1.0.1):
     - Sourcery
 
 DEPENDENCIES:
@@ -21,7 +21,7 @@ SPEC CHECKSUMS:
   RxBlocking: 923c2c8106d80d7c2d6b276afd66ce3b10824836
   RxSwift: fd680d75283beb5e2559486f3c0ff852f0d35334
   Sourcery: e3829460a1fa0bcd3b689e6087a89cc063cd2289
-  SwiftyMocky: 5c65fdb6939253b8f8a6acd8e4892e91a26396d9
+  SwiftyMocky: 35d1e7ddc247699f2276becc3855ab25dd6bb27c
 
 PODFILE CHECKSUM: a2473869e45fc6c9d085871be68447dee1e0afe5
 

--- a/Sources/Classes/Matcher.swift
+++ b/Sources/Classes/Matcher.swift
@@ -42,6 +42,7 @@ public class Matcher {
         matchers.append((mirror, match as Any))
     }
 
+#if swift(>=3.2)
     /// Register sequence comparator, based on elements comparing.
     ///
     /// - Parameters:
@@ -62,6 +63,28 @@ public class Matcher {
             return true
         }
     }
+#else
+    /// Register sequence comparator, based on elements comparing.
+    ///
+    /// - Parameters:
+    ///   - valueType: Sequence type
+    ///   - match: Element comparator closure
+    public func register<T>(_ valueType: T.Type, match: @escaping (T.Iterator.Element,T.Iterator.Element) -> Bool) where T: Sequence {
+        let mirror = Mirror(reflecting: T.Iterator.Element.self)
+        matchers.append((mirror, match as Any))
+        register(T.self) { (l: T, r: T) -> Bool in
+            let lhs = l.map { $0 }
+            let rhs = r.map { $0 }
+            guard lhs.count == rhs.count else { return false }
+
+            for i in 0..<lhs.count {
+                guard match(lhs[i],rhs[i]) else { return false }
+            }
+
+            return true
+        }
+    }
+#endif
 
     /// Register default comparatot for Equatable types. Required for generic mocks to work.
     ///
@@ -89,6 +112,7 @@ public class Matcher {
         return comparator as? (T,T) -> Bool
     }
 
+#if swift(>=3.2)
     /// Default Sequence comparator, compares count, and then element by element.
     ///
     /// - Parameter valueType: Sequence type
@@ -117,6 +141,36 @@ public class Matcher {
             return nil
         }
     }
+#else
+    /// Default Sequence comparator, compares count, and then element by element.
+    ///
+    /// - Parameter valueType: Sequence type
+    /// - Returns: comparator closure
+    public func comparator<T>(for valueType: T.Type) -> ((T,T) -> Bool)? where T: Sequence {
+        let mirror = Mirror(reflecting: valueType)
+        let comparator = matchers.reversed().first { (current, _) -> Bool in
+            return current.subjectType == mirror.subjectType
+        }?.1
+
+        if let compare = comparator as? (T,T) -> Bool {
+            return compare
+        } else if let compare = self.comparator(for: T.Iterator.Element.self) {
+            return { (l: T, r: T) -> Bool in
+                let lhs = l.map { $0 }
+                let rhs = r.map { $0 }
+                guard lhs.count == rhs.count else { return false }
+
+                for i in 0..<lhs.count {
+                    guard compare(lhs[i],rhs[i]) else { return false }
+                }
+
+                return true
+            }
+        } else {
+            return nil
+        }
+    }
+#endif
 
     /// Default Equatable comparator, compares if elements are equal.
     ///


### PR DESCRIPTION
Fixes inconsistency in handling different Swift versions. Main point of change is between Swift 3.2 and 3.1, where handling Sequence Element changed.

Should work under following setups:
- Xcode 8.3 Swift 3.1 (lowest supported)
- Xcode 8.3.3 Swift 3.1
- Xcode 9, Swift 3.2 and 4.0+