### PR TITLE
Feature/106 mock methods differing only return type

### DIFF
--- a/Mocky.xcodeproj/project.pbxproj
+++ b/Mocky.xcodeproj/project.pbxproj
@@ -12,6 +12,12 @@
 		61B65D431C6E4154C44B6B1D /* Pods_Mocky_Example_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D435D6B1D3850EB6C36B69E /* Pods_Mocky_Example_iOS.framework */; };
 		6A629255223ACC1B05F1B6D7 /* Pods_Mocky_Tests_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 835A7223A01A944E0F3E0BCF /* Pods_Mocky_Tests_macOS.framework */; };
 		7D1174B528873ECD259B355C /* Pods_Mocky_Example_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 356426D9A4F6925FCD6469A5 /* Pods_Mocky_Example_tvOS.framework */; };
+		CC07B603202215F600F51534 /* ProtocolMethodsThatDifferOnlyInReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07B601202215D500F51534 /* ProtocolMethodsThatDifferOnlyInReturnType.swift */; };
+		CC07B604202215F600F51534 /* ProtocolMethodsThatDifferOnlyInReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07B601202215D500F51534 /* ProtocolMethodsThatDifferOnlyInReturnType.swift */; };
+		CC07B605202215F700F51534 /* ProtocolMethodsThatDifferOnlyInReturnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07B601202215D500F51534 /* ProtocolMethodsThatDifferOnlyInReturnType.swift */; };
+		CC07B60820221B6700F51534 /* ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07B60720221B6700F51534 /* ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift */; };
+		CC07B60920221B6700F51534 /* ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07B60720221B6700F51534 /* ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift */; };
+		CC07B60A20221B6700F51534 /* ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07B60720221B6700F51534 /* ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift */; };
 		CC3252172003CC22009AD6C2 /* Excluded.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3252162003CC22009AD6C2 /* Excluded.generated.swift */; };
 		CC3252182003CC22009AD6C2 /* Excluded.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3252162003CC22009AD6C2 /* Excluded.generated.swift */; };
 		CC3252192003CC22009AD6C2 /* Excluded.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3252162003CC22009AD6C2 /* Excluded.generated.swift */; };
@@ -184,6 +190,8 @@
 		AAEE52510F67C7DF13FF8AF2 /* Pods-Mocky_Example_tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mocky_Example_tvOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Mocky_Example_tvOS/Pods-Mocky_Example_tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		BCB5C12EDA17046011396E79 /* Pods-Mocky_Tests_tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mocky_Tests_tvOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Mocky_Tests_tvOS/Pods-Mocky_Tests_tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		CAC0C2FE2E105DB67A93DC7E /* Pods_Mocky_Example_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Mocky_Example_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC07B601202215D500F51534 /* ProtocolMethodsThatDifferOnlyInReturnType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolMethodsThatDifferOnlyInReturnType.swift; sourceTree = "<group>"; };
+		CC07B60720221B6700F51534 /* ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift; sourceTree = "<group>"; };
 		CC3252162003CC22009AD6C2 /* Excluded.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Excluded.generated.swift; sourceTree = "<group>"; };
 		CC32521A2004C217009AD6C2 /* GenericProtocolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericProtocolsTests.swift; sourceTree = "<group>"; };
 		CC32521E20051AC9009AD6C2 /* SelfConstrainedProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfConstrainedProtocol.swift; sourceTree = "<group>"; };
@@ -404,6 +412,22 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		CC07B600202215C200F51534 /* Example 9 */ = {
+			isa = PBXGroup;
+			children = (
+				CC07B601202215D500F51534 /* ProtocolMethodsThatDifferOnlyInReturnType.swift */,
+			);
+			path = "Example 9";
+			sourceTree = "<group>";
+		};
+		CC07B60620221B4B00F51534 /* Example 9 */ = {
+			isa = PBXGroup;
+			children = (
+				CC07B60720221B6700F51534 /* ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift */,
+			);
+			path = "Example 9";
+			sourceTree = "<group>";
+		};
 		CC491A1C1FDAB48F001CAB8A /* Example 8 */ = {
 			isa = PBXGroup;
 			children = (
@@ -506,6 +530,7 @@
 				CCE350D91FCC0A9400A76C4C /* Example 6 */,
 				CCE350D71FCC0A9400A76C4C /* Example 7 */,
 				CC491A1C1FDAB48F001CAB8A /* Example 8 */,
+				CC07B600202215C200F51534 /* Example 9 */,
 				CCE350DE1FCC0A9400A76C4C /* Model */,
 				CCE350D11FCC0A9400A76C4C /* Other */,
 			);
@@ -628,6 +653,7 @@
 				CCE351351FCC0B8200A76C4C /* Example 6 */,
 				CCE351331FCC0B8200A76C4C /* Example 7 */,
 				CC491A221FDAB56F001CAB8A /* Example 8 */,
+				CC07B60620221B4B00F51534 /* Example 9 */,
 				CCE3512F1FCC0B8200A76C4C /* Other */,
 			);
 			path = Shared;
@@ -1341,6 +1367,7 @@
 				CCE350F61FCC0A9400A76C4C /* ProtocolWithInitializers.swift in Sources */,
 				CCE350EA1FCC0A9400A76C4C /* NonSwiftProtocol.swift in Sources */,
 				CCE351061FCC0A9400A76C4C /* ProtocolsWithClosures.swift in Sources */,
+				CC07B604202215F600F51534 /* ProtocolMethodsThatDifferOnlyInReturnType.swift in Sources */,
 				CCE350F01FCC0A9400A76C4C /* GenericProtocols.swift in Sources */,
 				CCE351041FCC0A9400A76C4C /* ProtocolWithThrowingMethods.swift in Sources */,
 				CCE350F21FCC0A9400A76C4C /* SampleService.swift in Sources */,
@@ -1360,6 +1387,7 @@
 				CCE351431FCC0B8200A76C4C /* SampleServiceTests.swift in Sources */,
 				CCE351571FCC0B8200A76C4C /* ProtocolWithClosuresTests.swift in Sources */,
 				CCE351531FCC0B8200A76C4C /* ProtocolsWithCustomAttributesTests.swift in Sources */,
+				CC07B60920221B6700F51534 /* ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift in Sources */,
 				CCE3514B1FCC0B8200A76C4C /* ProtocolWithInitializersTests.swift in Sources */,
 				CCE351551FCC0B8200A76C4C /* ProtocolWithThrowingMehtodsTests.swift in Sources */,
 				CCE351661FCC0B9700A76C4C /* Mock.generated.swift in Sources */,
@@ -1392,6 +1420,7 @@
 				CCE350F51FCC0A9400A76C4C /* ProtocolWithInitializers.swift in Sources */,
 				CCE350E91FCC0A9400A76C4C /* NonSwiftProtocol.swift in Sources */,
 				CCE351051FCC0A9400A76C4C /* ProtocolsWithClosures.swift in Sources */,
+				CC07B603202215F600F51534 /* ProtocolMethodsThatDifferOnlyInReturnType.swift in Sources */,
 				CCE350EF1FCC0A9400A76C4C /* GenericProtocols.swift in Sources */,
 				CCE351031FCC0A9400A76C4C /* ProtocolWithThrowingMethods.swift in Sources */,
 				CCE350F11FCC0A9400A76C4C /* SampleService.swift in Sources */,
@@ -1410,6 +1439,7 @@
 				CCE3514E1FCC0B8200A76C4C /* SimpleProtocolsTests.swift in Sources */,
 				CCE351421FCC0B8200A76C4C /* SampleServiceTests.swift in Sources */,
 				CCE351561FCC0B8200A76C4C /* ProtocolWithClosuresTests.swift in Sources */,
+				CC07B60820221B6700F51534 /* ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift in Sources */,
 				CCE351521FCC0B8200A76C4C /* ProtocolsWithCustomAttributesTests.swift in Sources */,
 				CC491A251FDAB587001CAB8A /* ProtocolWithPropertiesTests.swift in Sources */,
 				CCE3514A1FCC0B8200A76C4C /* ProtocolWithInitializersTests.swift in Sources */,
@@ -1442,6 +1472,7 @@
 				CC5B61DB1FCC18C4007FB209 /* SampleService.swift in Sources */,
 				CC5B61D91FCC18C4007FB209 /* ItemsRepository.swift in Sources */,
 				CC5B61D31FCC18C4007FB209 /* ProtocolWithInitializers.swift in Sources */,
+				CC07B605202215F700F51534 /* ProtocolMethodsThatDifferOnlyInReturnType.swift in Sources */,
 				CC5B61CF1FCC18C4007FB209 /* ProtocolWithThrowingMethods.swift in Sources */,
 				CC5B61D51FCC18C4007FB209 /* Item.swift in Sources */,
 				CC5B61BE1FCC1764007FB209 /* ViewController.swift in Sources */,
@@ -1461,6 +1492,7 @@
 				CC5B61E11FCC18D0007FB209 /* ProtocolWithClosuresTests.swift in Sources */,
 				CC5B61CC1FCC188D007FB209 /* ItemsRepositoryMock.swift in Sources */,
 				CC5B61CB1FCC188D007FB209 /* Mock.generated.swift in Sources */,
+				CC07B60A20221B6700F51534 /* ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift in Sources */,
 				CC5B61E01FCC18D0007FB209 /* ProtocolWithStaticMembersTests.swift in Sources */,
 				CC5B61C61FCC178F007FB209 /* Mocky_Example_macOSTests.swift in Sources */,
 				CC5B61E21FCC18D0007FB209 /* ProtocolWithInitializersTests.swift in Sources */,

--- a/Sources/Templates/Mock.swifttemplate
+++ b/Sources/Templates/Mock.swifttemplate
@@ -768,6 +768,49 @@ import SourceryRuntime
         }
 
         func areSameMethods(_ m1: SourceryRuntime.Method, _ m2: SourceryRuntime.Method) -> Bool {
+            guard m1.name != m2.name else { return m1.returnTypeName == m2.returnTypeName }
+            guard m1.selectorName == m2.selectorName else { return false }
+            guard m1.parameters.count == m2.parameters.count else { return false }
+
+            let p1 = m1.parameters
+            let p2 = m2.parameters
+
+            for i in 0..<p1.count {
+                if !areSameParams(p1[i],p2[i]) { return false }
+            }
+
+            return m1.returnTypeName == m2.returnTypeName
+        }
+
+        return methods.reduce([], { (result, element) -> [SourceryRuntime.Method] in
+            guard !result.contains(where: { areSameMethods($0,element) }) else { return result }
+            return result + [element]
+        })
+    }
+
+    func uniquesWithoutGenericConstraints(methods: [SourceryRuntime.Method]) -> [SourceryRuntime.Method] {
+        func returnTypeStripped(_ method: SourceryRuntime.Method) -> String {
+            let returnTypeRaw = "\(method.returnTypeName)"
+            var stripped: String = {
+                guard let range = returnTypeRaw.range(of: "where") else { return returnTypeRaw }
+                var stripped = returnTypeRaw
+                stripped.removeSubrange((range.lowerBound)...)
+                return stripped
+            }()
+            stripped = stripped.trimmingCharacters(in: CharacterSet(charactersIn: " "))
+            return stripped
+        }
+
+        func areSameParams(_ p1: SourceryRuntime.MethodParameter, _ p2: SourceryRuntime.MethodParameter) -> Bool {
+            guard p1.argumentLabel == p2.argumentLabel else { return false }
+            guard p1.name == p2.name else { return false }
+            guard p1.argumentLabel == p2.argumentLabel else { return false }
+            guard p1.typeName.name == p2.typeName.name else { return false }
+            guard p1.actualTypeName?.name == p2.actualTypeName?.name else { return false }
+            return true
+        }
+
+        func areSameMethods(_ m1: SourceryRuntime.Method, _ m2: SourceryRuntime.Method) -> Bool {
             guard m1.name != m2.name else { return returnTypeStripped(m1) == returnTypeStripped(m2) }
             guard m1.selectorName == m2.selectorName else { return false }
             guard m1.parameters.count == m2.parameters.count else { return false }
@@ -886,7 +929,9 @@ import SourceryRuntime
     let allStaticVariables = uniques(variables: aProtocol.allVariables.filter({ $0.isStatic }))
     let containsStaticVariables = !allStaticVariables.isEmpty
     let allMethods = uniques(methods: aProtocol.allMethods.filter({ !$0.isStatic }))
+    let allMethodsForMethodType = uniquesWithoutGenericConstraints(methods: aProtocol.allMethods.filter({ !$0.isStatic }))
     let allStaticMethods = uniques(methods: aProtocol.allMethods.filter({ $0.isStatic }))
+    let allStaticMethodsForMethodType = uniquesWithoutGenericConstraints(methods: aProtocol.allMethods.filter({ $0.isStatic }))
     let conformsToStaticMock = !allStaticMethods.isEmpty || !allStaticVariables.isEmpty
     let conformsToMock = !allMethods.isEmpty || !allVariables.isEmpty -%><%_ -%><%_ -%>
 <%_ if autoMockable { -%>
@@ -950,8 +995,10 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
     <%_ MethodWrapper.clear() -%>
     <%_ Current.selfType = "\(type.name)Mock\(genericTypesModifier)" -%>
     <%_ let wrappedMethods = allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) -%>
+    <%_ let wrappedMethodsForMethodType = allMethodsForMethodType.map(wrapMethod).filter({ $0.wrappedInMethodType() }) -%>
     <%_ let wrappedInitializers = allMethods.map(wrapMethod).filter({ $0.method.isInitializer }) -%>
     <%_ let wrappedStaticMethods = allStaticMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) -%>
+    <%_ let wrappedStaticMethodsForMethodType = allStaticMethodsForMethodType.map(wrapMethod).filter({ $0.wrappedInMethodType() }) -%>
     <%_ for variable in allVariables { propertyRegister(variable) } -%>
     <%_ for variable in allStaticVariables { propertyRegister(variable) } -%>
     <%_ for method in wrappedMethods { method.register() } -%>
@@ -981,7 +1028,7 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
   <%# ================================================== STATIC METHOD TYPE -%><%_ -%>
     <%_ if conformsToStaticMock { -%>
     fileprivate enum StaticMethodType {
-    <%_ for method in wrappedStaticMethods { -%>
+    <%_ for method in wrappedStaticMethodsForMethodType { -%>
         case <%= method.methodTypeDeclarationWithParameters() _%>
     <%_  } %>
     <%_ for variable in allStaticVariables { -%>
@@ -989,7 +1036,7 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
     <%_ } %> <%_ %>
     <%_ -%>
         static func compareParameters(lhs: StaticMethodType, rhs: StaticMethodType, matcher: Matcher) -> Bool {
-            switch (lhs, rhs) { <%_ for method in wrappedStaticMethods { %>
+            switch (lhs, rhs) { <%_ for method in wrappedStaticMethodsForMethodType { %>
                 <%= method.equalCase -%><% for parameter in method.parameters { %>
                     <%= parameter.comparator -%> <%  } %>
                     return true <% } %>
@@ -1003,7 +1050,7 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
         }
     <%_ %>
         func intValue() -> Int {
-            switch self { <%_ for method in wrappedStaticMethods { %>
+            switch self { <%_ for method in wrappedStaticMethodsForMethodType { %>
                 <%= method.intValueCase -%><% } %>
                 <%_ for variable in allStaticVariables { -%>
                 <%= propertyMethodTypesIntValue(variable) %>
@@ -1023,12 +1070,12 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
             self.`throws` = `throws`
         }
 
-        <%_ for method in wrappedStaticMethods.filter({ !$0.method.returnTypeName.isVoid && !$0.method.isInitializer }) { -%>
+        <%_ for method in wrappedStaticMethodsForMethodType.filter({ !$0.method.returnTypeName.isVoid && !$0.method.isInitializer }) { -%>
         <%= method.givenConstructorName(prefix: "Static") -%> {
             <%= method.givenConstructor(prefix: "Static") _%>
         }
         <%_ } -%>
-        <%_ for method in wrappedStaticMethods.filter({ ($0.method.throws || $0.method.rethrows) && !$0.method.isInitializer }) { -%>
+        <%_ for method in wrappedStaticMethodsForMethodType.filter({ ($0.method.throws || $0.method.rethrows) && !$0.method.isInitializer }) { -%>
         <%= method.givenConstructorNameThrows(prefix: "Static") -%> {
             <%= method.givenConstructorThrows(prefix: "Static") _%>
         }
@@ -1038,7 +1085,7 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
     struct StaticVerify {
         fileprivate var method: StaticMethodType
 
-        <%_ for method in wrappedStaticMethods { -%>
+        <%_ for method in wrappedStaticMethodsForMethodType { -%>
         <%= method.verificationProxyConstructorName(prefix: "Static") -%> {
             <%= method.verificationProxyConstructor(prefix: "Static") _%>
         }
@@ -1049,7 +1096,7 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
         fileprivate var method: StaticMethodType
         var performs: Any
 
-        <%_ for method in wrappedStaticMethods { -%>
+        <%_ for method in wrappedStaticMethodsForMethodType { -%>
         <%= method.performProxyConstructorName(prefix: "Static") -%> {
             <%= method.performProxyConstructor(prefix: "Static") _%>
         }
@@ -1060,7 +1107,7 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
   <%# ================================================== METHOD TYPE -%><%_ -%>
     <%_ if !wrappedMethods.isEmpty || !allVariables.isEmpty { -%>
     fileprivate enum MethodType {
-    <%_ for method in wrappedMethods { -%>
+    <%_ for method in wrappedMethodsForMethodType { -%>
         case <%= method.methodTypeDeclarationWithParameters() _%>
     <%_  } -%>
     <%_ for variable in allVariables { -%>
@@ -1068,7 +1115,7 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
     <%_ } %> <%_ %>
     <%_ -%>
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Bool {
-            switch (lhs, rhs) { <%_ for method in wrappedMethods { %>
+            switch (lhs, rhs) { <%_ for method in wrappedMethodsForMethodType { %>
                 <%= method.equalCase -%><% for parameter in method.parameters { %>
                     <%= parameter.comparator -%> <%  } %>
                     return true <% } %>
@@ -1082,7 +1129,7 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
         }
     <%_ %>
         func intValue() -> Int {
-            switch self { <%_ for method in wrappedMethods { %>
+            switch self { <%_ for method in wrappedMethodsForMethodType { %>
                 <%= method.intValueCase -%><% } %>
                 <%_ for variable in allVariables { -%>
                 <%= propertyMethodTypesIntValue(variable) %>
@@ -1108,12 +1155,12 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
             self.`throws` = `throws`
         }
 
-        <%_ for method in wrappedMethods.filter({ !$0.method.returnTypeName.isVoid && !$0.method.isInitializer }) { -%>
+        <%_ for method in wrappedMethodsForMethodType.filter({ !$0.method.returnTypeName.isVoid && !$0.method.isInitializer }) { -%>
         <%= method.givenConstructorName() -%> {
             <%= method.givenConstructor() _%>
         }
         <%_ } -%>
-        <%_ for method in wrappedMethods.filter({ ($0.method.throws || $0.method.rethrows) && !$0.method.isInitializer }) { -%>
+        <%_ for method in wrappedMethodsForMethodType.filter({ ($0.method.throws || $0.method.rethrows) && !$0.method.isInitializer }) { -%>
         <%= method.givenConstructorNameThrows() -%> {
             <%= method.givenConstructorThrows() _%>
         }
@@ -1123,7 +1170,7 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
     struct Verify {
         fileprivate var method: MethodType
 
-        <%_ for method in wrappedMethods { -%>
+        <%_ for method in wrappedMethodsForMethodType { -%>
         <%= method.verificationProxyConstructorName() -%> {
             <%= method.verificationProxyConstructor() _%>
         }
@@ -1134,7 +1181,7 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
         fileprivate var method: MethodType
         var performs: Any
 
-        <%_ for method in wrappedMethods { -%>
+        <%_ for method in wrappedMethodsForMethodType { -%>
         <%= method.performProxyConstructorName() -%> {
             <%= method.performProxyConstructor() _%>
         }

--- a/Sources/Templates/Mock.swifttemplate
+++ b/Sources/Templates/Mock.swifttemplate
@@ -324,43 +324,50 @@ import SourceryRuntime
     class MethodWrapper {
         private static var registered: [String: Int] = [:]
         private static var suffixes: [String: Int] = [:]
+        private static var suffixesWithoutReturnType: [String: Int] = [:]
 
         let method: SourceryRuntime.Method
 
         private var registrationName: String {
-            get {
-                var rawName = (method.isStatic ? "s\(method.selectorName)" : "i\(method.selectorName)")
-                    .replacingOccurrences(of: "_", with: "")
-                    .replacingOccurrences(of: "(", with: "__")
-                    .replacingOccurrences(of: ")", with: "")
+            var rawName = (method.isStatic ? "s\(method.selectorName)" : "i\(method.selectorName)")
+                .replacingOccurrences(of: "_", with: "")
+                .replacingOccurrences(of: "(", with: "__")
+                .replacingOccurrences(of: ")", with: "")
+            var parametersNames = method.parameters.map { "\($0.name)" }
 
-                var parametersNames = method.parameters.map { "\($0.name)" }
-
-                while let range = rawName.range(of: ":"), let name = parametersNames.first {
-                    parametersNames.removeFirst()
-                    rawName.replaceSubrange(range, with: "_\(name)")
-                }
-
-                return  rawName.replacingOccurrences(of: "___", with: "__").trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+            while let range = rawName.range(of: ":"), let name = parametersNames.first {
+                parametersNames.removeFirst()
+                rawName.replaceSubrange(range, with: "_\(name)")
             }
+
+            return  rawName.replacingOccurrences(of: "___", with: "__").trimmingCharacters(in: CharacterSet(charactersIn: "_"))
         }
         private var uniqueName: String {
-            get {
-                var rawName = (method.isStatic ? "s\(method.selectorName)" : "i\(method.selectorName)")
-                var parametersNames = method.parameters.map { "\($0.name)_of_\($0.typeName.name)" }
+            var rawName = (method.isStatic ? "s\(method.selectorName)" : "i\(method.selectorName)")
+            var parametersNames = method.parameters.map { "\($0.name)_of_\($0.typeName.name)" }
 
-                while let range = rawName.range(of: ":"), let name = parametersNames.first {
-                    parametersNames.removeFirst()
-                    rawName.replaceSubrange(range, with: "_\(name)")
-                }
-
-                return rawName.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+            while let range = rawName.range(of: ":"), let name = parametersNames.first {
+                parametersNames.removeFirst()
+                rawName.replaceSubrange(range, with: "_\(name)")
             }
+
+            return rawName.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+        }
+        private var uniqueNameWithReturnType: String {
+            let returnTypeRaw = "\(method.returnTypeName)"
+            var returnTypeStripped: String = {
+                guard let range = returnTypeRaw.range(of: "where") else { return returnTypeRaw }
+                var stripped = returnTypeRaw
+                stripped.removeSubrange((range.lowerBound)...)
+                return stripped
+            }()
+            returnTypeStripped = returnTypeStripped.trimmingCharacters(in: CharacterSet(charactersIn: " "))
+            return "\(uniqueName)->\(returnTypeStripped)"
         }
         private var nameSuffix: String {
             guard let count = MethodWrapper.registered[registrationName] else { return "" }
             guard count > 1 else { return "" }
-            guard let index = MethodWrapper.suffixes[uniqueName] else { return "" }
+            guard let index = MethodWrapper.suffixes[uniqueNameWithReturnType] else { return "" }
             return "_\(index)"
         }
 
@@ -465,25 +472,45 @@ import SourceryRuntime
         static func clear() -> String {
             MethodWrapper.registered = [:]
             MethodWrapper.suffixes = [:]
+            MethodWrapper.suffixesWithoutReturnType = [:]
             return ""
         }
 
         func register() {
-            MethodWrapper.register(registrationName,uniqueName)
+            MethodWrapper.register(registrationName,uniqueName,uniqueNameWithReturnType)
         }
 
-        static func register(_ name: String, _ uniqueName: String) {
+        static func register(_ name: String, _ uniqueName: String, _ uniqueNameWithReturnType: String) {
             if let count = MethodWrapper.registered[name] {
                 MethodWrapper.registered[name] = count + 1
-                MethodWrapper.suffixes[uniqueName] = count + 1
+                MethodWrapper.suffixes[uniqueNameWithReturnType] = count + 1
             } else {
                 MethodWrapper.registered[name] = 1
-                MethodWrapper.suffixes[uniqueName] = 1
+                MethodWrapper.suffixes[uniqueNameWithReturnType] = 1
             }
+
+            if let count = MethodWrapper.suffixesWithoutReturnType[uniqueName] {
+                MethodWrapper.suffixesWithoutReturnType[uniqueName] = count + 1
+            } else {
+                MethodWrapper.suffixesWithoutReturnType[uniqueName] = 1
+            }
+        }
+
+        func returnTypeMatters() -> Bool {
+            let count = MethodWrapper.suffixesWithoutReturnType[uniqueName] ?? 0
+            return count > 1
         }
 
         func wrappedInMethodType() -> Bool {
             return !method.isInitializer
+        }
+
+        func returningParameter(_ multiple: Bool, _ front: Bool) -> String {
+            guard returnTypeMatters() else { return "" }
+            let returning: String = "returning: \(returnTypeStripped(method, type: true))"
+            guard multiple else { return returning }
+
+            return front ? ", \(returning)" : "\(returning), "
         }
 
         // Stub
@@ -574,9 +601,9 @@ import SourceryRuntime
         // Verify
         func verificationProxyConstructorName(prefix: String = "") -> String {
             if method.parameters.isEmpty {
-                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))() -> \(prefix)Verify"
+                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))(\(returningParameter(false,true))) -> \(prefix)Verify"
             } else {
-                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))(\(parametersForProxySignature())) -> \(prefix)Verify"
+                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))(\(parametersForProxySignature())\(returningParameter(true,true))) -> \(prefix)Verify"
             }
         }
 
@@ -591,9 +618,9 @@ import SourceryRuntime
         // Perform
         func performProxyConstructorName(prefix: String = "") -> String {
             if method.parameters.isEmpty {
-                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))(perform: \(performProxyClosureType())) -> \(prefix)Perform"
+                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))(\(returningParameter(true,false))perform: \(performProxyClosureType())) -> \(prefix)Perform"
             } else {
-                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))(\(parametersForProxySignature()), perform: \(performProxyClosureType())) -> \(prefix)Perform"
+                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))(\(parametersForProxySignature()), \(returningParameter(true,false))perform: \(performProxyClosureType())) -> \(prefix)Perform"
             }
         }
 
@@ -703,9 +730,34 @@ import SourceryRuntime
         private func stripGenPart(part: String) -> String {
             return part.characters.split(separator: ":").map(String.init).first!
         }
+
+        private func returnTypeStripped(_ method: SourceryRuntime.Method, type: Bool = false) -> String {
+            let returnTypeRaw = "\(method.returnTypeName)"
+            var stripped: String = {
+                guard let range = returnTypeRaw.range(of: "where") else { return returnTypeRaw }
+                var stripped = returnTypeRaw
+                stripped.removeSubrange((range.lowerBound)...)
+                return stripped
+            }()
+            stripped = stripped.trimmingCharacters(in: CharacterSet(charactersIn: " "))
+            guard type else { return stripped }
+            return "\(stripped).Type"
+        }
     }
 
     func uniques(methods: [SourceryRuntime.Method]) -> [SourceryRuntime.Method] {
+        func returnTypeStripped(_ method: SourceryRuntime.Method) -> String {
+            let returnTypeRaw = "\(method.returnTypeName)"
+            var stripped: String = {
+                guard let range = returnTypeRaw.range(of: "where") else { return returnTypeRaw }
+                var stripped = returnTypeRaw
+                stripped.removeSubrange((range.lowerBound)...)
+                return stripped
+            }()
+            stripped = stripped.trimmingCharacters(in: CharacterSet(charactersIn: " "))
+            return stripped
+        }
+
         func areSameParams(_ p1: SourceryRuntime.MethodParameter, _ p2: SourceryRuntime.MethodParameter) -> Bool {
             guard p1.argumentLabel == p2.argumentLabel else { return false }
             guard p1.name == p2.name else { return false }
@@ -716,7 +768,7 @@ import SourceryRuntime
         }
 
         func areSameMethods(_ m1: SourceryRuntime.Method, _ m2: SourceryRuntime.Method) -> Bool {
-            guard m1.name != m2.name else { return true }
+            guard m1.name != m2.name else { return returnTypeStripped(m1) == returnTypeStripped(m2) }
             guard m1.selectorName == m2.selectorName else { return false }
             guard m1.parameters.count == m2.parameters.count else { return false }
 
@@ -727,7 +779,7 @@ import SourceryRuntime
                 if !areSameParams(p1[i],p2[i]) { return false }
             }
 
-            return true
+            return returnTypeStripped(m1) == returnTypeStripped(m2)
         }
 
         return methods.reduce([], { (result, element) -> [SourceryRuntime.Method] in
@@ -774,8 +826,8 @@ import SourceryRuntime
 
     func propertyRegister(_ variable: SourceryRuntime.Variable) {
         let wrapper = VariableWrapper(variable, scope: "")
-        MethodWrapper.register(wrapper.propertyCaseGetName,wrapper.propertyCaseGetName)
-        MethodWrapper.register(wrapper.propertyCaseSetName,wrapper.propertyCaseSetName)
+        MethodWrapper.register(wrapper.propertyCaseGetName,wrapper.propertyCaseGetName,wrapper.propertyCaseGetName)
+        MethodWrapper.register(wrapper.propertyCaseSetName,wrapper.propertyCaseSetName,wrapper.propertyCaseGetName)
     }
 -%>
 

--- a/SwiftyMocky-Example/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnType.swift
+++ b/SwiftyMocky-Example/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnType.swift
@@ -1,0 +1,15 @@
+//
+//  ProtocolWithSimilarMethods.swift
+//  SwiftyMocky
+//
+//  Created by Andrzej Michnia on 31.01.2018.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import Foundation
+
+//sourcery: AutoMockable
+protocol ProtocolMethodsThatDifferOnlyInReturnType {
+    func foo(bar: String) -> String
+    func foo(bar: String) -> Int
+}

--- a/SwiftyMocky-Example/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnType.swift
+++ b/SwiftyMocky-Example/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnType.swift
@@ -13,3 +13,25 @@ protocol ProtocolMethodsThatDifferOnlyInReturnType {
     func foo(bar: String) -> String
     func foo(bar: String) -> Int
 }
+
+class A {
+    let id: Int
+    init(_ id: Int) {
+        self.id = id
+    }
+}
+class B {
+    let id: Int
+    init(_ id: Int) {
+        self.id = id
+    }
+}
+
+//sourcery: AutoMockable
+protocol ProtocolMethodsGenericThatDifferOnlyInReturnType {
+    func foo<T>(bar: T) -> String
+    func foo<T>(bar: T) -> Int
+    func foo<T>(bar: T) -> Float where T: A
+    func foo<T>(bar: T) -> Float where T: B
+    func foo<T>(bar: T) -> Double where T: B
+}

--- a/SwiftyMocky-Tests/Shared/Example 8/ProtocolWithPropertiesTests.swift
+++ b/SwiftyMocky-Tests/Shared/Example 8/ProtocolWithPropertiesTests.swift
@@ -93,4 +93,3 @@ class ProtocolsWithPropertiesTests: XCTestCase {
         VerifyProperty(mock, .in(range: 10...), .name(set: .any))
     }
 }
-

--- a/SwiftyMocky-Tests/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift
+++ b/SwiftyMocky-Tests/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift
@@ -1,0 +1,41 @@
+//
+//  ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift
+//  Mocky
+//
+//  Created by Andrzej Michnia on 31.01.2018.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import XCTest
+import SwiftyMocky
+#if os(iOS)
+    @testable import Mocky_Example_iOS
+#elseif os(tvOS)
+    @testable import Mocky_Example_tvOS
+#elseif os(macOS)
+    @testable import Mocky_Example_macOS
+#endif
+
+class ProtocolMethodsThatDifferOnlyInReturnTypeTests: XCTestCase {
+    func test_simple_case() {
+        let mock = ProtocolMethodsThatDifferOnlyInReturnTypeMock()
+
+        Given(mock, .foo(bar: .any, willReturn: 1))
+        Given(mock, .foo(bar: .value("sth"), willReturn: 2))
+        Given(mock, .foo(bar: .any, willReturn: "any"))
+
+        Verify(mock, .never, .foo(bar: .any, returning: Int.self))
+        Verify(mock, .never, .foo(bar: .any, returning: String.self))
+
+        XCTAssertEqual(mock.foo(bar: "aaa"), 1)
+
+        Verify(mock, 1, .foo(bar: .any, returning: Int.self))
+        Verify(mock, .never, .foo(bar: .any, returning: String.self))
+
+        XCTAssertEqual(mock.foo(bar: "sth"), 2)
+        XCTAssertEqual(mock.foo(bar: "sth"), "any")
+
+        Verify(mock, 2, .foo(bar: .any, returning: Int.self))
+        Verify(mock, 1, .foo(bar: .any, returning: String.self))
+    }
+}

--- a/SwiftyMocky-Tests/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift
+++ b/SwiftyMocky-Tests/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift
@@ -38,4 +38,35 @@ class ProtocolMethodsThatDifferOnlyInReturnTypeTests: XCTestCase {
         Verify(mock, 2, .foo(bar: .any, returning: Int.self))
         Verify(mock, 1, .foo(bar: .any, returning: String.self))
     }
+
+    func test_generic_case() {
+        let mock = ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock()
+
+        Matcher.default.register(A.self) { lhs,rhs in
+            return lhs.id == rhs.id
+        }
+        Matcher.default.register(B.self) { lhs,rhs in
+            return lhs.id == rhs.id
+        }
+
+        Given(mock, .foo(bar: .any(A.self), willReturn: Float(0)))
+        Given(mock, .foo(bar: .any(B.self), willReturn: Float(1)))
+        Given(mock, .foo(bar: .value(B(2)), willReturn: Float(2)))
+        Given(mock, .foo(bar: .any(Int.self), willReturn: 3))
+
+        Verify(mock, .never, .foo(bar: .any(A.self), returning: Float.self))
+        Verify(mock, .never, .foo(bar: .any(B.self), returning: Float.self))
+        Verify(mock, .never, .foo(bar: .any(Int.self), returning: Int.self))
+
+        let v1: Float = mock.foo(bar: A(0))
+        XCTAssertEqual(v1, 0)
+        let v2: Float = mock.foo(bar: B(1))
+        XCTAssertEqual(v2, 1)
+        let v3: Float = mock.foo(bar: B(2))
+        XCTAssertEqual(v3, 2)
+
+        Verify(mock, 1, .foo(bar: .any(A.self), returning: Float.self))
+        Verify(mock, 2, .foo(bar: .any(B.self), returning: Float.self))
+        Verify(mock, .never, .foo(bar: .any(Int.self), returning: Int.self))
+    }
 }

--- a/SwiftyMocky-Tests/iOS/Mocks/Mock.generated.swift
+++ b/SwiftyMocky-Tests/iOS/Mocks/Mock.generated.swift
@@ -1652,6 +1652,195 @@ class NonSwiftProtocolMock: NSObject, NonSwiftProtocol, Mock {
     }
 }
 
+// MARK: - ProtocolMethodsGenericThatDifferOnlyInReturnType
+class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGenericThatDifferOnlyInReturnType, Mock {
+    private var invocations: [MethodType] = []
+    private var methodReturnValues: [Given] = []
+    private var methodPerformValues: [Perform] = []
+    var matcher: Matcher = Matcher.default
+
+
+    typealias Property = Swift.Never
+
+
+    func foo<T>(bar: T) -> String {
+        addInvocation(.ifoo__bar_bar_1(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_1(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_1(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? String
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Int {
+        addInvocation(.ifoo__bar_bar_2(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_2(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_2(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Int
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Float where T: A {
+        addInvocation(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Float
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Float where T: B {
+        addInvocation(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Float
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Double where T: B {
+        addInvocation(.ifoo__bar_bar_5(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_5(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_5(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Double
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    fileprivate enum MethodType {
+        case ifoo__bar_bar_1(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_2(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_4(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_5(Parameter<GenericAttribute>)
+
+        static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Bool {
+            switch (lhs, rhs) {
+                case (.ifoo__bar_bar_1(let lhsBar), .ifoo__bar_bar_1(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_2(let lhsBar), .ifoo__bar_bar_2(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_4(let lhsBar), .ifoo__bar_bar_4(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_5(let lhsBar), .ifoo__bar_bar_5(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                default: return false
+            }
+        }
+
+        func intValue() -> Int {
+            switch self {
+                case let .ifoo__bar_bar_1(p0): return p0.intValue
+                case let .ifoo__bar_bar_2(p0): return p0.intValue
+                case let .ifoo__bar_bar_4(p0): return p0.intValue
+                case let .ifoo__bar_bar_5(p0): return p0.intValue
+            }
+        }
+    }
+
+    struct Given {
+        fileprivate var method: MethodType
+        var returns: Any?
+        var `throws`: Error?
+
+        private init(method: MethodType, returns: Any?, throws: Error?) {
+            self.method = method
+            self.returns = returns
+            self.`throws` = `throws`
+        }
+
+        static func foo<T>(bar: Parameter<T>, willReturn: String) -> Given {
+            return Given(method: .ifoo__bar_bar_1(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<T>, willReturn: Int) -> Given {
+            return Given(method: .ifoo__bar_bar_2(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<T>, willReturn: Float) -> Given {
+            return Given(method: .ifoo__bar_bar_4(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<T>, willReturn: Double) -> Given {
+            return Given(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+    }
+
+    struct Verify {
+        fileprivate var method: MethodType
+
+        static func foo<T>(bar: Parameter<T>, returning: String.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_1(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Int.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_2(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Float.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_4(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Double.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()))
+        }
+    }
+
+    struct Perform {
+        fileprivate var method: MethodType
+        var performs: Any
+
+        static func foo<T>(bar: Parameter<T>, returning: String.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_1(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Int.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_2(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Float.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_4(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Double.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), performs: perform)
+        }
+    }
+
+    private func matchingCalls(_ method: Verify) -> Int {
+        return matchingCalls(method.method).count
+    }
+
+    public func given(_ method: Given) {
+        methodReturnValues.append(method)
+        methodReturnValues.sort { $0.method.intValue() < $1.method.intValue() }
+    }
+
+    public func perform(_ method: Perform) {
+        methodPerformValues.append(method)
+        methodPerformValues.sort { $0.method.intValue() < $1.method.intValue() }
+    }
+
+    public func verify(_ method: Verify, count: Count = Count.moreOrEqual(to: 1), file: StaticString = #file, line: UInt = #line) {
+        let invocations = matchingCalls(method.method)
+        MockyAssert(count.matches(invocations.count), "Expeced: \(count) invocations of `\(method.method)`, but was: \(invocations.count)", file: file, line: line)
+    }
+    public func verify(property: Property, count: Count = Count.moreOrEqual(to: 1), file: StaticString = #file, line: UInt = #line) { }
+
+    private func addInvocation(_ call: MethodType) {
+        invocations.append(call)
+    }
+
+    private func methodReturnValue(_ method: MethodType) -> (value: Any?, error: Error?) {
+        let matched = methodReturnValues.reversed().first { MethodType.compareParameters(lhs: $0.method, rhs: method, matcher: matcher)  }
+        return (value: matched?.returns, error: matched?.`throws`)
+    }
+
+    private func methodPerformValue(_ method: MethodType) -> Any? {
+        let matched = methodPerformValues.reversed().first { MethodType.compareParameters(lhs: $0.method, rhs: method, matcher: matcher) }
+        return matched?.performs
+    }
+
+    private func matchingCalls(_ method: MethodType) -> [MethodType] {
+        return invocations.filter { MethodType.compareParameters(lhs: $0, rhs: method, matcher: matcher) }
+    }
+}
+
 // MARK: - ProtocolMethodsThatDifferOnlyInReturnType
 class ProtocolMethodsThatDifferOnlyInReturnTypeMock: ProtocolMethodsThatDifferOnlyInReturnType, Mock {
     private var invocations: [MethodType] = []

--- a/SwiftyMocky-Tests/macOS/Mocks/Mock.generated.swift
+++ b/SwiftyMocky-Tests/macOS/Mocks/Mock.generated.swift
@@ -1652,6 +1652,195 @@ class NonSwiftProtocolMock: NSObject, NonSwiftProtocol, Mock {
     }
 }
 
+// MARK: - ProtocolMethodsGenericThatDifferOnlyInReturnType
+class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGenericThatDifferOnlyInReturnType, Mock {
+    private var invocations: [MethodType] = []
+    private var methodReturnValues: [Given] = []
+    private var methodPerformValues: [Perform] = []
+    var matcher: Matcher = Matcher.default
+
+
+    typealias Property = Swift.Never
+
+
+    func foo<T>(bar: T) -> String {
+        addInvocation(.ifoo__bar_bar_1(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_1(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_1(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? String
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Int {
+        addInvocation(.ifoo__bar_bar_2(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_2(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_2(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Int
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Float where T: A {
+        addInvocation(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Float
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Float where T: B {
+        addInvocation(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Float
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Double where T: B {
+        addInvocation(.ifoo__bar_bar_5(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_5(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_5(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Double
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    fileprivate enum MethodType {
+        case ifoo__bar_bar_1(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_2(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_4(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_5(Parameter<GenericAttribute>)
+
+        static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Bool {
+            switch (lhs, rhs) {
+                case (.ifoo__bar_bar_1(let lhsBar), .ifoo__bar_bar_1(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_2(let lhsBar), .ifoo__bar_bar_2(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_4(let lhsBar), .ifoo__bar_bar_4(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_5(let lhsBar), .ifoo__bar_bar_5(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                default: return false
+            }
+        }
+
+        func intValue() -> Int {
+            switch self {
+                case let .ifoo__bar_bar_1(p0): return p0.intValue
+                case let .ifoo__bar_bar_2(p0): return p0.intValue
+                case let .ifoo__bar_bar_4(p0): return p0.intValue
+                case let .ifoo__bar_bar_5(p0): return p0.intValue
+            }
+        }
+    }
+
+    struct Given {
+        fileprivate var method: MethodType
+        var returns: Any?
+        var `throws`: Error?
+
+        private init(method: MethodType, returns: Any?, throws: Error?) {
+            self.method = method
+            self.returns = returns
+            self.`throws` = `throws`
+        }
+
+        static func foo<T>(bar: Parameter<T>, willReturn: String) -> Given {
+            return Given(method: .ifoo__bar_bar_1(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<T>, willReturn: Int) -> Given {
+            return Given(method: .ifoo__bar_bar_2(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<T>, willReturn: Float) -> Given {
+            return Given(method: .ifoo__bar_bar_4(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<T>, willReturn: Double) -> Given {
+            return Given(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+    }
+
+    struct Verify {
+        fileprivate var method: MethodType
+
+        static func foo<T>(bar: Parameter<T>, returning: String.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_1(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Int.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_2(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Float.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_4(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Double.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()))
+        }
+    }
+
+    struct Perform {
+        fileprivate var method: MethodType
+        var performs: Any
+
+        static func foo<T>(bar: Parameter<T>, returning: String.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_1(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Int.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_2(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Float.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_4(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Double.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), performs: perform)
+        }
+    }
+
+    private func matchingCalls(_ method: Verify) -> Int {
+        return matchingCalls(method.method).count
+    }
+
+    public func given(_ method: Given) {
+        methodReturnValues.append(method)
+        methodReturnValues.sort { $0.method.intValue() < $1.method.intValue() }
+    }
+
+    public func perform(_ method: Perform) {
+        methodPerformValues.append(method)
+        methodPerformValues.sort { $0.method.intValue() < $1.method.intValue() }
+    }
+
+    public func verify(_ method: Verify, count: Count = Count.moreOrEqual(to: 1), file: StaticString = #file, line: UInt = #line) {
+        let invocations = matchingCalls(method.method)
+        MockyAssert(count.matches(invocations.count), "Expeced: \(count) invocations of `\(method.method)`, but was: \(invocations.count)", file: file, line: line)
+    }
+    public func verify(property: Property, count: Count = Count.moreOrEqual(to: 1), file: StaticString = #file, line: UInt = #line) { }
+
+    private func addInvocation(_ call: MethodType) {
+        invocations.append(call)
+    }
+
+    private func methodReturnValue(_ method: MethodType) -> (value: Any?, error: Error?) {
+        let matched = methodReturnValues.reversed().first { MethodType.compareParameters(lhs: $0.method, rhs: method, matcher: matcher)  }
+        return (value: matched?.returns, error: matched?.`throws`)
+    }
+
+    private func methodPerformValue(_ method: MethodType) -> Any? {
+        let matched = methodPerformValues.reversed().first { MethodType.compareParameters(lhs: $0.method, rhs: method, matcher: matcher) }
+        return matched?.performs
+    }
+
+    private func matchingCalls(_ method: MethodType) -> [MethodType] {
+        return invocations.filter { MethodType.compareParameters(lhs: $0, rhs: method, matcher: matcher) }
+    }
+}
+
 // MARK: - ProtocolMethodsThatDifferOnlyInReturnType
 class ProtocolMethodsThatDifferOnlyInReturnTypeMock: ProtocolMethodsThatDifferOnlyInReturnType, Mock {
     private var invocations: [MethodType] = []

--- a/SwiftyMocky-Tests/tvOS/Mocks/Mock.generated.swift
+++ b/SwiftyMocky-Tests/tvOS/Mocks/Mock.generated.swift
@@ -1652,6 +1652,195 @@ class NonSwiftProtocolMock: NSObject, NonSwiftProtocol, Mock {
     }
 }
 
+// MARK: - ProtocolMethodsGenericThatDifferOnlyInReturnType
+class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGenericThatDifferOnlyInReturnType, Mock {
+    private var invocations: [MethodType] = []
+    private var methodReturnValues: [Given] = []
+    private var methodPerformValues: [Perform] = []
+    var matcher: Matcher = Matcher.default
+
+
+    typealias Property = Swift.Never
+
+
+    func foo<T>(bar: T) -> String {
+        addInvocation(.ifoo__bar_bar_1(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_1(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_1(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? String
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Int {
+        addInvocation(.ifoo__bar_bar_2(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_2(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_2(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Int
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Float where T: A {
+        addInvocation(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Float
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Float where T: B {
+        addInvocation(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_4(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Float
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    func foo<T>(bar: T) -> Double where T: B {
+        addInvocation(.ifoo__bar_bar_5(Parameter<T>.value(bar).wrapAsGeneric()))
+		let perform = methodPerformValue(.ifoo__bar_bar_5(Parameter<T>.value(bar).wrapAsGeneric())) as? (T) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_5(Parameter<T>.value(bar).wrapAsGeneric()))
+		let value = givenValue.value as? Double
+		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
+    }
+
+    fileprivate enum MethodType {
+        case ifoo__bar_bar_1(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_2(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_4(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_5(Parameter<GenericAttribute>)
+
+        static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Bool {
+            switch (lhs, rhs) {
+                case (.ifoo__bar_bar_1(let lhsBar), .ifoo__bar_bar_1(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_2(let lhsBar), .ifoo__bar_bar_2(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_4(let lhsBar), .ifoo__bar_bar_4(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_5(let lhsBar), .ifoo__bar_bar_5(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                default: return false
+            }
+        }
+
+        func intValue() -> Int {
+            switch self {
+                case let .ifoo__bar_bar_1(p0): return p0.intValue
+                case let .ifoo__bar_bar_2(p0): return p0.intValue
+                case let .ifoo__bar_bar_4(p0): return p0.intValue
+                case let .ifoo__bar_bar_5(p0): return p0.intValue
+            }
+        }
+    }
+
+    struct Given {
+        fileprivate var method: MethodType
+        var returns: Any?
+        var `throws`: Error?
+
+        private init(method: MethodType, returns: Any?, throws: Error?) {
+            self.method = method
+            self.returns = returns
+            self.`throws` = `throws`
+        }
+
+        static func foo<T>(bar: Parameter<T>, willReturn: String) -> Given {
+            return Given(method: .ifoo__bar_bar_1(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<T>, willReturn: Int) -> Given {
+            return Given(method: .ifoo__bar_bar_2(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<T>, willReturn: Float) -> Given {
+            return Given(method: .ifoo__bar_bar_4(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<T>, willReturn: Double) -> Given {
+            return Given(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
+        }
+    }
+
+    struct Verify {
+        fileprivate var method: MethodType
+
+        static func foo<T>(bar: Parameter<T>, returning: String.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_1(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Int.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_2(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Float.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_4(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Double.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()))
+        }
+    }
+
+    struct Perform {
+        fileprivate var method: MethodType
+        var performs: Any
+
+        static func foo<T>(bar: Parameter<T>, returning: String.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_1(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Int.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_2(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Float.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_4(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<T>, returning: Double.Type, perform: (T) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), performs: perform)
+        }
+    }
+
+    private func matchingCalls(_ method: Verify) -> Int {
+        return matchingCalls(method.method).count
+    }
+
+    public func given(_ method: Given) {
+        methodReturnValues.append(method)
+        methodReturnValues.sort { $0.method.intValue() < $1.method.intValue() }
+    }
+
+    public func perform(_ method: Perform) {
+        methodPerformValues.append(method)
+        methodPerformValues.sort { $0.method.intValue() < $1.method.intValue() }
+    }
+
+    public func verify(_ method: Verify, count: Count = Count.moreOrEqual(to: 1), file: StaticString = #file, line: UInt = #line) {
+        let invocations = matchingCalls(method.method)
+        MockyAssert(count.matches(invocations.count), "Expeced: \(count) invocations of `\(method.method)`, but was: \(invocations.count)", file: file, line: line)
+    }
+    public func verify(property: Property, count: Count = Count.moreOrEqual(to: 1), file: StaticString = #file, line: UInt = #line) { }
+
+    private func addInvocation(_ call: MethodType) {
+        invocations.append(call)
+    }
+
+    private func methodReturnValue(_ method: MethodType) -> (value: Any?, error: Error?) {
+        let matched = methodReturnValues.reversed().first { MethodType.compareParameters(lhs: $0.method, rhs: method, matcher: matcher)  }
+        return (value: matched?.returns, error: matched?.`throws`)
+    }
+
+    private func methodPerformValue(_ method: MethodType) -> Any? {
+        let matched = methodPerformValues.reversed().first { MethodType.compareParameters(lhs: $0.method, rhs: method, matcher: matcher) }
+        return matched?.performs
+    }
+
+    private func matchingCalls(_ method: MethodType) -> [MethodType] {
+        return invocations.filter { MethodType.compareParameters(lhs: $0, rhs: method, matcher: matcher) }
+    }
+}
+
 // MARK: - ProtocolMethodsThatDifferOnlyInReturnType
 class ProtocolMethodsThatDifferOnlyInReturnTypeMock: ProtocolMethodsThatDifferOnlyInReturnType, Mock {
     private var invocations: [MethodType] = []


### PR DESCRIPTION
Added handling methods that differs only in return type.

Fixes: #106 