### PR TITLE
Move SwiftLint rules to top before any code

### DIFF
--- a/Sources/Templates/Mock.swifttemplate
+++ b/Sources/Templates/Mock.swifttemplate
@@ -1,4 +1,11 @@
 
+<%# ================================================== SwiftLint -%><%_ -%>
+<%_ if let rules = arguments["excludedSwiftLintRules"] as? [String] { -%>
+    <%_ for rule in rules { -%>
+    <%_ %>//swiftlint:disable <%= rule %>
+    <%_ } -%>
+<%_ } -%>
+
 #if MockyCustom
 import SwiftyMocky
 <%# ================================================== IMPORTS InAPP -%><%_ -%>
@@ -59,13 +66,6 @@ import XCTest
 import Sourcery
 import SourceryRuntime
 #endif
-
-<%# ================================================== SwiftLint -%><%_ -%>
-<%_ if let rules = arguments["excludedSwiftLintRules"] as? [String] { -%>
-    <%_ for rule in rules { -%>
-    <%_ %>//swiftlint:disable <%= rule %>
-    <%_ } -%>
-<%_ } -%>
 
 <%# ================================================== HELPERS -%><%_
     class Current {


### PR DESCRIPTION
The code between the first `#if MockyCustom` and `#endif` was generating SwiftLint errors for me. Since the excluded SwiftLint rules part came after that code, there was no way to prevent this. Moving the SwiftLint rules to the top of the generated file fixes this.