### PR TITLE
fix for generic methods that differ only in return type

### DIFF
--- a/Sources/Templates/Mock.swifttemplate
+++ b/Sources/Templates/Mock.swifttemplate
@@ -601,9 +601,11 @@ import SourceryRuntime
         // Verify
         func verificationProxyConstructorName(prefix: String = "") -> String {
             if method.parameters.isEmpty {
-                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))(\(returningParameter(false,true))) -> \(prefix)Verify"
+                let methodName = returnTypeMatters() ? method.shortName : "\(method.callName)\(wrapGenerics(getGenericsAmongParameters()))"
+                return "static func \(methodName)(\(returningParameter(false,true))) -> \(prefix)Verify"
             } else {
-                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))(\(parametersForProxySignature())\(returningParameter(true,true))) -> \(prefix)Verify"
+                let methodName = returnTypeMatters() ? method.shortName : "\(method.callName)\(wrapGenerics(getGenericsAmongParameters()))"
+                return "static func \(methodName)(\(parametersForProxySignature())\(returningParameter(true,true))) -> \(prefix)Verify"
             }
         }
 
@@ -618,9 +620,11 @@ import SourceryRuntime
         // Perform
         func performProxyConstructorName(prefix: String = "") -> String {
             if method.parameters.isEmpty {
-                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))(\(returningParameter(true,false))perform: \(performProxyClosureType())) -> \(prefix)Perform"
+                let methodName = returnTypeMatters() ? method.shortName : "\(method.callName)\(wrapGenerics(getGenericsAmongParameters()))"
+                return "static func \(methodName)(\(returningParameter(true,false))perform: \(performProxyClosureType())) -> \(prefix)Perform"
             } else {
-                return "static func \(method.callName)\(wrapGenerics(getGenericsAmongParameters()))(\(parametersForProxySignature()), \(returningParameter(true,false))perform: \(performProxyClosureType())) -> \(prefix)Perform"
+                let methodName = returnTypeMatters() ? method.shortName : "\(method.callName)\(wrapGenerics(getGenericsAmongParameters()))"
+                return "static func \(methodName)(\(parametersForProxySignature()), \(returningParameter(true,false))perform: \(performProxyClosureType())) -> \(prefix)Perform"
             }
         }
 

--- a/SwiftyMocky-Example/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnType.swift
+++ b/SwiftyMocky-Example/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnType.swift
@@ -34,4 +34,8 @@ protocol ProtocolMethodsGenericThatDifferOnlyInReturnType {
     func foo<T>(bar: T) -> Float where T: A
     func foo<T>(bar: T) -> Float where T: B
     func foo<T>(bar: T) -> Double where T: B
+    func foo<T>(bar: String) -> Array<T>
+    func foo<T>(bar: String) -> Set<T>
+    func foo<T>(bar: Bool) -> T where T: A
+    func foo<T>(bar: Bool) -> T where T: B
 }

--- a/SwiftyMocky-Tests/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift
+++ b/SwiftyMocky-Tests/Shared/Example 9/ProtocolMethodsThatDifferOnlyInReturnTypeTests.swift
@@ -53,10 +53,14 @@ class ProtocolMethodsThatDifferOnlyInReturnTypeTests: XCTestCase {
         Given(mock, .foo(bar: .any(B.self), willReturn: Float(1)))
         Given(mock, .foo(bar: .value(B(2)), willReturn: Float(2)))
         Given(mock, .foo(bar: .any(Int.self), willReturn: 3))
+        Given(mock, .foo(bar: .any(String.self), willReturn: [1, 2]))
+        Given(mock, .foo(bar: .any(String.self), willReturn: [1, 2, 3] as Set))
 
         Verify(mock, .never, .foo(bar: .any(A.self), returning: Float.self))
         Verify(mock, .never, .foo(bar: .any(B.self), returning: Float.self))
         Verify(mock, .never, .foo(bar: .any(Int.self), returning: Int.self))
+        Verify(mock, .never, .foo(bar: .any(String.self), returning: [Int].self))
+        Verify(mock, .never, .foo(bar: .any(String.self), returning: Set<Int>.self))
 
         let v1: Float = mock.foo(bar: A(0))
         XCTAssertEqual(v1, 0)
@@ -64,9 +68,13 @@ class ProtocolMethodsThatDifferOnlyInReturnTypeTests: XCTestCase {
         XCTAssertEqual(v2, 1)
         let v3: Float = mock.foo(bar: B(2))
         XCTAssertEqual(v3, 2)
+        let v4: Set<Int> = mock.foo(bar: "0")
+        XCTAssertEqual(v4, [1, 2, 3])
 
         Verify(mock, 1, .foo(bar: .any(A.self), returning: Float.self))
         Verify(mock, 2, .foo(bar: .any(B.self), returning: Float.self))
         Verify(mock, .never, .foo(bar: .any(Int.self), returning: Int.self))
+        Verify(mock, .never, .foo(bar: .any(String.self), returning: [Int].self))
+        Verify(mock, 1, .foo(bar: .any(String.self), returning: Set<Int>.self))
     }
 }

--- a/SwiftyMocky-Tests/iOS/Mocks/Mock.generated.swift
+++ b/SwiftyMocky-Tests/iOS/Mocks/Mock.generated.swift
@@ -1708,11 +1708,50 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
 		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
     }
 
+    func foo<T>(bar: String) -> Array<T> {
+        addInvocation(.ifoo__bar_bar_6(Parameter<String>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_6(Parameter<String>.value(bar))) as? (String) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_6(Parameter<String>.value(bar)))
+		let value = givenValue.value as? Array<T>
+		return value.orFail("stub return value not specified for foo<T>(bar: String). Use given")
+    }
+
+    func foo<T>(bar: String) -> Set<T> {
+        addInvocation(.ifoo__bar_bar_7(Parameter<String>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_7(Parameter<String>.value(bar))) as? (String) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_7(Parameter<String>.value(bar)))
+		let value = givenValue.value as? Set<T>
+		return value.orFail("stub return value not specified for foo<T>(bar: String). Use given")
+    }
+
+    func foo<T>(bar: Bool) -> T where T: A {
+        addInvocation(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar))) as? (Bool) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let value = givenValue.value as? T
+		return value.orFail("stub return value not specified for foo<T>(bar: Bool). Use given")
+    }
+
+    func foo<T>(bar: Bool) -> T where T: B {
+        addInvocation(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar))) as? (Bool) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let value = givenValue.value as? T
+		return value.orFail("stub return value not specified for foo<T>(bar: Bool). Use given")
+    }
+
     fileprivate enum MethodType {
         case ifoo__bar_bar_1(Parameter<GenericAttribute>)
         case ifoo__bar_bar_2(Parameter<GenericAttribute>)
         case ifoo__bar_bar_4(Parameter<GenericAttribute>)
         case ifoo__bar_bar_5(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_6(Parameter<String>)
+        case ifoo__bar_bar_7(Parameter<String>)
+        case ifoo__bar_bar_9(Parameter<Bool>)
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Bool {
             switch (lhs, rhs) {
@@ -1728,6 +1767,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
                 case (.ifoo__bar_bar_5(let lhsBar), .ifoo__bar_bar_5(let rhsBar)):
                     guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
                     return true 
+                case (.ifoo__bar_bar_6(let lhsBar), .ifoo__bar_bar_6(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_7(let lhsBar), .ifoo__bar_bar_7(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_9(let lhsBar), .ifoo__bar_bar_9(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
                 default: return false
             }
         }
@@ -1738,6 +1786,9 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
                 case let .ifoo__bar_bar_2(p0): return p0.intValue
                 case let .ifoo__bar_bar_4(p0): return p0.intValue
                 case let .ifoo__bar_bar_5(p0): return p0.intValue
+                case let .ifoo__bar_bar_6(p0): return p0.intValue
+                case let .ifoo__bar_bar_7(p0): return p0.intValue
+                case let .ifoo__bar_bar_9(p0): return p0.intValue
             }
         }
     }
@@ -1765,6 +1816,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
         static func foo<T>(bar: Parameter<T>, willReturn: Double) -> Given {
             return Given(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
         }
+        static func foo<T>(bar: Parameter<String>, willReturn: Array<T>) -> Given {
+            return Given(method: .ifoo__bar_bar_6(bar), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<String>, willReturn: Set<T>) -> Given {
+            return Given(method: .ifoo__bar_bar_7(bar), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<Bool>, willReturn: T) -> Given {
+            return Given(method: .ifoo__bar_bar_9(bar), returns: willReturn, throws: nil)
+        }
     }
 
     struct Verify {
@@ -1781,6 +1841,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
         }
         static func foo<T>(bar: Parameter<T>, returning: Double.Type) -> Verify {
             return Verify(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Array<T>.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_6(bar))
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Set<T>.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_7(bar))
+        }
+        static func foo<T>(bar: Parameter<Bool>, returning: T.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_9(bar))
         }
     }
 
@@ -1799,6 +1868,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
         }
         static func foo<T>(bar: Parameter<T>, returning: Double.Type, perform: (T) -> Void) -> Perform {
             return Perform(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Array<T>.Type, perform: (String) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_6(bar), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Set<T>.Type, perform: (String) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_7(bar), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<Bool>, returning: T.Type, perform: (Bool) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_9(bar), performs: perform)
         }
     }
 

--- a/SwiftyMocky-Tests/macOS/Mocks/Mock.generated.swift
+++ b/SwiftyMocky-Tests/macOS/Mocks/Mock.generated.swift
@@ -1708,11 +1708,50 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
 		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
     }
 
+    func foo<T>(bar: String) -> Array<T> {
+        addInvocation(.ifoo__bar_bar_6(Parameter<String>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_6(Parameter<String>.value(bar))) as? (String) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_6(Parameter<String>.value(bar)))
+		let value = givenValue.value as? Array<T>
+		return value.orFail("stub return value not specified for foo<T>(bar: String). Use given")
+    }
+
+    func foo<T>(bar: String) -> Set<T> {
+        addInvocation(.ifoo__bar_bar_7(Parameter<String>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_7(Parameter<String>.value(bar))) as? (String) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_7(Parameter<String>.value(bar)))
+		let value = givenValue.value as? Set<T>
+		return value.orFail("stub return value not specified for foo<T>(bar: String). Use given")
+    }
+
+    func foo<T>(bar: Bool) -> T where T: A {
+        addInvocation(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar))) as? (Bool) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let value = givenValue.value as? T
+		return value.orFail("stub return value not specified for foo<T>(bar: Bool). Use given")
+    }
+
+    func foo<T>(bar: Bool) -> T where T: B {
+        addInvocation(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar))) as? (Bool) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let value = givenValue.value as? T
+		return value.orFail("stub return value not specified for foo<T>(bar: Bool). Use given")
+    }
+
     fileprivate enum MethodType {
         case ifoo__bar_bar_1(Parameter<GenericAttribute>)
         case ifoo__bar_bar_2(Parameter<GenericAttribute>)
         case ifoo__bar_bar_4(Parameter<GenericAttribute>)
         case ifoo__bar_bar_5(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_6(Parameter<String>)
+        case ifoo__bar_bar_7(Parameter<String>)
+        case ifoo__bar_bar_9(Parameter<Bool>)
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Bool {
             switch (lhs, rhs) {
@@ -1728,6 +1767,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
                 case (.ifoo__bar_bar_5(let lhsBar), .ifoo__bar_bar_5(let rhsBar)):
                     guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
                     return true 
+                case (.ifoo__bar_bar_6(let lhsBar), .ifoo__bar_bar_6(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_7(let lhsBar), .ifoo__bar_bar_7(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_9(let lhsBar), .ifoo__bar_bar_9(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
                 default: return false
             }
         }
@@ -1738,6 +1786,9 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
                 case let .ifoo__bar_bar_2(p0): return p0.intValue
                 case let .ifoo__bar_bar_4(p0): return p0.intValue
                 case let .ifoo__bar_bar_5(p0): return p0.intValue
+                case let .ifoo__bar_bar_6(p0): return p0.intValue
+                case let .ifoo__bar_bar_7(p0): return p0.intValue
+                case let .ifoo__bar_bar_9(p0): return p0.intValue
             }
         }
     }
@@ -1765,6 +1816,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
         static func foo<T>(bar: Parameter<T>, willReturn: Double) -> Given {
             return Given(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
         }
+        static func foo<T>(bar: Parameter<String>, willReturn: Array<T>) -> Given {
+            return Given(method: .ifoo__bar_bar_6(bar), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<String>, willReturn: Set<T>) -> Given {
+            return Given(method: .ifoo__bar_bar_7(bar), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<Bool>, willReturn: T) -> Given {
+            return Given(method: .ifoo__bar_bar_9(bar), returns: willReturn, throws: nil)
+        }
     }
 
     struct Verify {
@@ -1781,6 +1841,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
         }
         static func foo<T>(bar: Parameter<T>, returning: Double.Type) -> Verify {
             return Verify(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Array<T>.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_6(bar))
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Set<T>.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_7(bar))
+        }
+        static func foo<T>(bar: Parameter<Bool>, returning: T.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_9(bar))
         }
     }
 
@@ -1799,6 +1868,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
         }
         static func foo<T>(bar: Parameter<T>, returning: Double.Type, perform: (T) -> Void) -> Perform {
             return Perform(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Array<T>.Type, perform: (String) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_6(bar), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Set<T>.Type, perform: (String) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_7(bar), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<Bool>, returning: T.Type, perform: (Bool) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_9(bar), performs: perform)
         }
     }
 

--- a/SwiftyMocky-Tests/tvOS/Mocks/Mock.generated.swift
+++ b/SwiftyMocky-Tests/tvOS/Mocks/Mock.generated.swift
@@ -1708,11 +1708,50 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
 		return value.orFail("stub return value not specified for foo<T>(bar: T). Use given")
     }
 
+    func foo<T>(bar: String) -> Array<T> {
+        addInvocation(.ifoo__bar_bar_6(Parameter<String>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_6(Parameter<String>.value(bar))) as? (String) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_6(Parameter<String>.value(bar)))
+		let value = givenValue.value as? Array<T>
+		return value.orFail("stub return value not specified for foo<T>(bar: String). Use given")
+    }
+
+    func foo<T>(bar: String) -> Set<T> {
+        addInvocation(.ifoo__bar_bar_7(Parameter<String>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_7(Parameter<String>.value(bar))) as? (String) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_7(Parameter<String>.value(bar)))
+		let value = givenValue.value as? Set<T>
+		return value.orFail("stub return value not specified for foo<T>(bar: String). Use given")
+    }
+
+    func foo<T>(bar: Bool) -> T where T: A {
+        addInvocation(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar))) as? (Bool) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let value = givenValue.value as? T
+		return value.orFail("stub return value not specified for foo<T>(bar: Bool). Use given")
+    }
+
+    func foo<T>(bar: Bool) -> T where T: B {
+        addInvocation(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let perform = methodPerformValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar))) as? (Bool) -> Void
+		perform?(bar)
+		let givenValue: (value: Any?, error: Error?) = methodReturnValue(.ifoo__bar_bar_9(Parameter<Bool>.value(bar)))
+		let value = givenValue.value as? T
+		return value.orFail("stub return value not specified for foo<T>(bar: Bool). Use given")
+    }
+
     fileprivate enum MethodType {
         case ifoo__bar_bar_1(Parameter<GenericAttribute>)
         case ifoo__bar_bar_2(Parameter<GenericAttribute>)
         case ifoo__bar_bar_4(Parameter<GenericAttribute>)
         case ifoo__bar_bar_5(Parameter<GenericAttribute>)
+        case ifoo__bar_bar_6(Parameter<String>)
+        case ifoo__bar_bar_7(Parameter<String>)
+        case ifoo__bar_bar_9(Parameter<Bool>)
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Bool {
             switch (lhs, rhs) {
@@ -1728,6 +1767,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
                 case (.ifoo__bar_bar_5(let lhsBar), .ifoo__bar_bar_5(let rhsBar)):
                     guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
                     return true 
+                case (.ifoo__bar_bar_6(let lhsBar), .ifoo__bar_bar_6(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_7(let lhsBar), .ifoo__bar_bar_7(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
+                case (.ifoo__bar_bar_9(let lhsBar), .ifoo__bar_bar_9(let rhsBar)):
+                    guard Parameter.compare(lhs: lhsBar, rhs: rhsBar, with: matcher) else { return false } 
+                    return true 
                 default: return false
             }
         }
@@ -1738,6 +1786,9 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
                 case let .ifoo__bar_bar_2(p0): return p0.intValue
                 case let .ifoo__bar_bar_4(p0): return p0.intValue
                 case let .ifoo__bar_bar_5(p0): return p0.intValue
+                case let .ifoo__bar_bar_6(p0): return p0.intValue
+                case let .ifoo__bar_bar_7(p0): return p0.intValue
+                case let .ifoo__bar_bar_9(p0): return p0.intValue
             }
         }
     }
@@ -1765,6 +1816,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
         static func foo<T>(bar: Parameter<T>, willReturn: Double) -> Given {
             return Given(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), returns: willReturn, throws: nil)
         }
+        static func foo<T>(bar: Parameter<String>, willReturn: Array<T>) -> Given {
+            return Given(method: .ifoo__bar_bar_6(bar), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<String>, willReturn: Set<T>) -> Given {
+            return Given(method: .ifoo__bar_bar_7(bar), returns: willReturn, throws: nil)
+        }
+        static func foo<T>(bar: Parameter<Bool>, willReturn: T) -> Given {
+            return Given(method: .ifoo__bar_bar_9(bar), returns: willReturn, throws: nil)
+        }
     }
 
     struct Verify {
@@ -1781,6 +1841,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
         }
         static func foo<T>(bar: Parameter<T>, returning: Double.Type) -> Verify {
             return Verify(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()))
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Array<T>.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_6(bar))
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Set<T>.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_7(bar))
+        }
+        static func foo<T>(bar: Parameter<Bool>, returning: T.Type) -> Verify {
+            return Verify(method: .ifoo__bar_bar_9(bar))
         }
     }
 
@@ -1799,6 +1868,15 @@ class ProtocolMethodsGenericThatDifferOnlyInReturnTypeMock: ProtocolMethodsGener
         }
         static func foo<T>(bar: Parameter<T>, returning: Double.Type, perform: (T) -> Void) -> Perform {
             return Perform(method: .ifoo__bar_bar_5(bar.wrapAsGeneric()), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Array<T>.Type, perform: (String) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_6(bar), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<String>, returning: Set<T>.Type, perform: (String) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_7(bar), performs: perform)
+        }
+        static func foo<T>(bar: Parameter<Bool>, returning: T.Type, perform: (Bool) -> Void) -> Perform {
+            return Perform(method: .ifoo__bar_bar_9(bar), performs: perform)
         }
     }
 


### PR DESCRIPTION
I found a bug when generic methods differ only in a generic return type:

```swift
    func foo<T>(bar: String) -> Array<T>
    func foo<T>(bar: String) -> Set<T>
```

At least for that simple example I fixed it. I’m not sure, if it still works, when the functions have several/other generic parameters.