### PR TITLE
Fix duplication of "Mock" in custom mocks

### DIFF
--- a/Sources/Templates/Mock.swifttemplate
+++ b/Sources/Templates/Mock.swifttemplate
@@ -969,7 +969,11 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
 
   <%# ================================================== VARIABLES -%><%_ -%>
     <%_ for variable in allVariables { -%>
+    <%_ if autoMockable { -%>
     <%= stubProperty(variable,"\(type.name)Mock") %>
+    <%_ } else { %>
+    <%= stubProperty(variable,"\(type.name)") %>
+    <%_ } %>
     <%_ } %> <%_ -%>
 
     <%_ if containsVariables { -%>
@@ -984,7 +988,11 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
     <%_ } %> <%_ -%>
   <%# ================================================== STATIC VARIABLES -%><%_ -%>
     <%_ for variable in allStaticVariables { -%>
+    <%_ if autoMockable { -%>
     <%= stubProperty(variable,"\(type.name)Mock") %>
+    <%_ } else { %>
+    <%= stubProperty(variable,"\(type.name)") %>
+    <%_ } %>
     <%_ } %> <%_ -%>
 
     <%_ if containsStaticVariables { -%>
@@ -999,7 +1007,11 @@ class <%= type.name %>Mock<%= genericTypesModifier %>:<%= type.annotations["Objc
     <%_ } %> <%_ -%>
   <%# ================================================== METHOD REGISTRATIONS -%><%_ -%>
     <%_ MethodWrapper.clear() -%>
+    <%_ if autoMockable { -%>
     <%_ Current.selfType = "\(type.name)Mock\(genericTypesModifier)" -%>
+    <%_ } else { %>
+    <%_ Current.selfType = "\(type.name)Mock\(genericTypesModifier)" -%>
+    <%_ } %>
     <%_ let wrappedMethods = allMethods.map(wrapMethod).filter({ $0.wrappedInMethodType() }) -%>
     <%_ let wrappedMethodsForMethodType = allMethodsForMethodType.map(wrapMethod).filter({ $0.wrappedInMethodType() }) -%>
     <%_ let wrappedInitializers = allMethods.map(wrapMethod).filter({ $0.method.isInitializer }) -%>


### PR DESCRIPTION
This was causing a compilation error when having to do a custom mock of a protocol that has static properties