### PR TITLE
Add ArgumentCaptor

### DIFF
--- a/Sources/Classes/ArgumentCaptor.swift
+++ b/Sources/Classes/ArgumentCaptor.swift
@@ -1,0 +1,26 @@
+//
+//  ArgumentCaptor.swift
+//  Pods
+//
+//  Created by TimeDelta on 15/04/2019.
+//
+//
+
+public class ArgumentCaptor<Type> {
+	/// Last captured value (if any)
+	public var value: Type? {
+		return allValues.last
+	}
+	/// All captured values
+	public private(set) var allValues = [Type]()
+
+	public init() {}
+
+	/// Return parameter matcher which captures the argument.
+	public func capture() -> Parameter<Type> {
+		return .matching({ (value: Type) -> Bool in
+			self.allValues.append(value)
+			return true
+		})
+	}
+}


### PR DESCRIPTION
For cases when you need to do something with the value(s) passed to a parameter
during, e.g., an integration test that uses some real values instead of pure mocks

Usage Example:
  let argumentCaptor = ArgumentCaptor&lt;UIAlertController&gt;()
  Verify(myMock, .myMethod(argumentCaptor.capture()))
  guard let controller = argumentCaptor.value else {
    XCTFail("Unable to get alert controller")
  }
  let action: UIAlertAction = controller.actions[0]
  action.tapButton(withTitle: "my button")
  // test effects of alert button handler