### PR TITLE
Remove MockyAssert functions from template and add them to a .swift file

### DIFF
--- a/Sources/Classes/MockyAssert.swift
+++ b/Sources/Classes/MockyAssert.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+#if MockyCustom
+public final class MockyAssertion {
+    public static var handler: ((Bool, String, StaticString, UInt) -> Void)?
+}
+
+public func MockyAssert(_ expression: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "Verification failed", file: StaticString = #file, line: UInt = #line) {
+    guard let handler = MockyAssertion.handler else {
+        assert(expression(), message(), file: file, line: line)
+        return
+    }
+
+    handler(expression(), message(), file, line)
+}
+#else
+public func MockyAssert(_ expression: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "Verification failed", file: StaticString = #file, line: UInt = #line) {
+    #if canImport(XCTest)
+    XCTAssert(expression(), message(), file: file, line: line)
+    #else
+    assert(expression(), message(), file: file, line: line)
+    #endif
+}
+#endif

--- a/Sources/Templates/Mock.swifttemplate
+++ b/Sources/Templates/Mock.swifttemplate
@@ -52,29 +52,6 @@ import XCTest
             <%_ %><%= projectImport %>
         <%_ } -%>
     <%_ } -%>
-<%# ================================================== ASSERTION -%><%_ -%>
-#if MockyCustom
-    public final class MockyAssertion {
-        public static var handler: ((Bool, String, StaticString, UInt) -> Void)?
-    }
-
-    func MockyAssert(_ expression: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "Verification failed", file: StaticString = #file, line: UInt = #line) {
-        guard let handler = MockyAssertion.handler else {
-            assert(expression(), message(), file: file, line: line)
-            return
-        }
-
-        handler(expression(), message(), file, line)
-    }
-#else
-    func MockyAssert(_ expression: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "Verification failed", file: StaticString = #file, line: UInt = #line) {
-        #if canImport(XCTest)
-        XCTAssert(expression(), message(), file: file, line: line)
-        #else 
-        assert(expression(), message(), file: file, line: line)
-        #endif
-    }
-#endif
 <%_
 class Current {
     static var selfType: String = "Self"

--- a/SwiftyMocky.xcodeproj/project.pbxproj
+++ b/SwiftyMocky.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		1D5310CA3DE7147ACC9E7E26 /* Pods_Mocky_Tests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64EF60CBE53D81700C87FB82 /* Pods_Mocky_Tests_tvOS.framework */; };
 		5CB0B098232DC176CC9CACD8 /* Pods_Mocky_Example_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9C9BECF310A1D4EDD384137 /* Pods_Mocky_Example_tvOS.framework */; };
 		66087FEBDA538F4C138743F2 /* Pods_Mocky_Example_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A4B259245C7FB13CDFFCEC0 /* Pods_Mocky_Example_iOS.framework */; };
+		68242AA222A7EBD300E36BCD /* MockyAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68242AA122A7EBD300E36BCD /* MockyAssert.swift */; };
+		68242AA322A7EF5400E36BCD /* MockyAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68242AA122A7EBD300E36BCD /* MockyAssert.swift */; };
 		7C10E4406673B3B3B7474E2C /* Pods_Mocky_Tests_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94B5EFCCD4E35E7C80D1E560 /* Pods_Mocky_Tests_macOS.framework */; };
 		AD487E872180A3CA005B74ED /* Count.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD487E862180A3CA005B74ED /* Count.swift */; };
 		BB4F9E470E0BD27A959C97EB /* Pods_Mocky_Tests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9592625386F952AE07781D57 /* Pods_Mocky_Tests_iOS.framework */; };
@@ -232,6 +234,7 @@
 		607FACD01AFB9204008FA782 /* Mocky_Example_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mocky_Example_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACE51AFB9204008FA782 /* Mocky_Tests_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Mocky_Tests_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		64EF60CBE53D81700C87FB82 /* Pods_Mocky_Tests_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Mocky_Tests_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		68242AA122A7EBD300E36BCD /* MockyAssert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockyAssert.swift; sourceTree = "<group>"; };
 		7194340B3CD91B825FCB78FB /* Pods-Mocky_Example_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mocky_Example_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Mocky_Example_iOS/Pods-Mocky_Example_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		7A9B02B1C24E9AC79ABF999C /* Pods-Mocky_Example_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mocky_Example_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Mocky_Example_iOS/Pods-Mocky_Example_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		8DDEF4635180A969B16362F7 /* Pods-Mocky_Tests_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mocky_Tests_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Mocky_Tests_iOS/Pods-Mocky_Tests_iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -621,6 +624,7 @@
 				AD487E862180A3CA005B74ED /* Count.swift */,
 				CC491A1A1FD9A33F001CAB8A /* Countable.swift */,
 				CCB026A71FB4F38F00ACA9F0 /* GenericAttribute.swift */,
+				68242AA122A7EBD300E36BCD /* MockyAssert.swift */,
 			);
 			name = Classes;
 			path = Sources/Classes;
@@ -1527,6 +1531,7 @@
 				C8294EB52299357E0036BC94 /* CustomAssertions.swift in Sources */,
 				C8294EBC2299357E0036BC94 /* Matcher.swift in Sources */,
 				C8294EBB2299357E0036BC94 /* Parameter+Literals.swift in Sources */,
+				68242AA322A7EF5400E36BCD /* MockyAssert.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1609,6 +1614,7 @@
 				C841941E2153D7E700D2BBC9 /* Parameter+Literals.swift in Sources */,
 				CCA9F818215668DF00F2880B /* Policies.swift in Sources */,
 				CCA9F816215668D800F2880B /* Stubbing.swift in Sources */,
+				68242AA222A7EBD300E36BCD /* MockyAssert.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This change is required to support multiple generated files in a test target.