### PR TITLE
make mock template generate internal variables where it needed

### DIFF
--- a/Sources/Templates/Mock.swifttemplate
+++ b/Sources/Templates/Mock.swifttemplate
@@ -1341,7 +1341,10 @@ class VariableWrapper {
     var readonly: Bool { return variable.writeAccess.isEmpty }
     var privatePrototypeName: String { return "__p_\(variable.name)".replacingOccurrences(of: "`", with: "") }
     var casesCount: Int { return readonly ? 1 : 2 }
-
+    var accessModifier: String {
+        guard variable.type?.accessLevel != "internal" else { return "" }
+        return "public "
+    }
     let deprecatedMessage = "Using setters on readonly variables is deprecated, and will be removed in 3.1. Use Given to define stubbed property return value."
     var noStubDefinedMessage: String { return "\(scope) - stub value for \(variable.name) was not defined" }
 
@@ -1362,7 +1365,7 @@ class VariableWrapper {
     var prototype: String {
         let staticModifier = variable.isStatic ? "static " : ""
 
-        return "public \(staticModifier)var \(variable.name): \(variable.typeName.name) {" +
+        return "\(accessModifier)\(staticModifier)var \(variable.name): \(variable.typeName.name) {" +
             "\(getter)" +
             "\(setter)" +
         "\n\t}"
@@ -1413,7 +1416,7 @@ class VariableWrapper {
 
     // Given
     func givenConstructorName(prefix: String = "") -> String {
-        return "public static func \(variable.name)(getter defaultValue: \(TypeWrapper(variable.typeName).stripped)...) -> \(prefix)PropertyStub"
+        return "\(accessModifier)static func \(variable.name)(getter defaultValue: \(TypeWrapper(variable.typeName).stripped)...) -> \(prefix)PropertyStub"
     }
 
     func givenConstructor(prefix: String = "") -> String {


### PR DESCRIPTION
* the issue is about mocking the protocols that has internal access modifier
* properties that contains instances of such protocols now generated like public
* it broke compilation of the app

Please take a look. I am very uncommon with mock template itself so there could be issues.
I checked on some big project before requesting - it works normal.