### PR TITLE
Pin Chalk version to 0.0.7

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,21 +11,21 @@
         }
       },
       {
+        "package": "Chalk",
+        "repositoryURL": "https://github.com/luoxiu/Chalk",
+        "state": {
+          "branch": null,
+          "revision": "a705a6ddbb338d8f350b3903c3eae7fd41140168",
+          "version": "0.0.4"
+        }
+      },
+      {
         "package": "Commander",
         "repositoryURL": "https://github.com/kylef/Commander",
         "state": {
           "branch": null,
           "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
           "version": "0.9.1"
-        }
-      },
-      {
-        "package": "Crayon",
-        "repositoryURL": "https://github.com/jianstm/Crayon",
-        "state": {
-          "branch": null,
-          "revision": "05930604feec1ac77b4633a17a722d428d5be2cc",
-          "version": "0.0.3"
         }
       },
       {
@@ -39,7 +39,7 @@
       },
       {
         "package": "Rainbow",
-        "repositoryURL": "https://github.com/jianstm/Rainbow",
+        "repositoryURL": "https://github.com/luoxiu/Rainbow",
         "state": {
           "branch": null,
           "revision": "177c6ebae4389c0363ea1bf62a7257151d53acbc",

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/luoxiu/Chalk",
         "state": {
           "branch": null,
-          "revision": "a705a6ddbb338d8f350b3903c3eae7fd41140168",
-          "version": "0.0.4"
+          "revision": "fbb0adbe8a54d8dbfcb4824ebc96bd3b401d0757",
+          "version": "0.0.7"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/luoxiu/Rainbow",
         "state": {
           "branch": null,
-          "revision": "177c6ebae4389c0363ea1bf62a7257151d53acbc",
-          "version": "0.0.4"
+          "revision": "438720f94da08582aff2abc4712de1c23f464d45",
+          "version": "0.0.5"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
         "state": {
           "branch": null,
-          "revision": "4ebf25863deb9c3c02696704fc3d39736183f258",
-          "version": "2.2.1"
+          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+          "version": "2.3.0"
         }
       },
       {
@@ -69,8 +69,17 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "23f7e12a7e0db29b4f16052692d99f9fbe41fa15",
-          "version": "7.5.0"
+          "revision": "912d40cc2ea4a300eff6dd7c6a10b4f4dedbcbec",
+          "version": "7.10.0"
+        }
+      },
+      {
+        "package": "XcodeProjCExt",
+        "repositoryURL": "https://github.com/tuist/XcodeProjCExt",
+        "state": {
+          "branch": null,
+          "revision": "21a510c225ff2bc83d5920a21d902af4b1e7e218",
+          "version": "0.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
        .package(url: "https://github.com/tuist/xcodeproj.git", from: "7.1.0"),
        .package(url: "https://github.com/luoxiu/Chalk", .exact("0.0.7")),
-       .package(url: "https://github.com/kylef/Commander", from: "0.8.0"),
+       .package(url: "https://github.com/kylef/Commander", .exact("0.9.1")),
        .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
        .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
    ],
@@ -58,7 +58,7 @@ let package = Package(
     dependencies: [
        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
        .package(url: "https://github.com/luoxiu/Chalk", .exact("0.0.7")),
-       .package(url: "https://github.com/kylef/Commander", from: "0.8.0"),
+       .package(url: "https://github.com/kylef/Commander", .exact("0.9.1")),
        .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
        .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
    dependencies: [
        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
        .package(url: "https://github.com/tuist/xcodeproj.git", from: "7.1.0"),
-       .package(url: "https://github.com/luoxiu/Chalk", from: "0.0.4"),
+       .package(url: "https://github.com/luoxiu/Chalk", .exact("0.0.7")),
        .package(url: "https://github.com/kylef/Commander", from: "0.8.0"),
        .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
        .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
@@ -57,7 +57,7 @@ let package = Package(
     ],
     dependencies: [
        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
-       .package(url: "https://github.com/luoxiu/Chalk", from: "0.0.4"),
+       .package(url: "https://github.com/luoxiu/Chalk", .exact("0.0.7")),
        .package(url: "https://github.com/kylef/Commander", from: "0.8.0"),
        .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
        .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
    dependencies: [
        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
        .package(url: "https://github.com/tuist/xcodeproj.git", from: "7.1.0"),
-       .package(url: "https://github.com/jianstm/Crayon", from: "0.0.3"),
+       .package(url: "https://github.com/luoxiu/Chalk", from: "0.0.4"),
        .package(url: "https://github.com/kylef/Commander", from: "0.8.0"),
        .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
        .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
@@ -34,7 +34,7 @@ let package = Package(
            name: "SwiftyMockyCLICore",
            dependencies: [
                "ShellOut",
-               "Crayon",
+               "Chalk",
                "XcodeProj",
                "PathKit",
                "Yams",
@@ -57,7 +57,7 @@ let package = Package(
     ],
     dependencies: [
        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
-       .package(url: "https://github.com/jianstm/Crayon", from: "0.0.3"),
+       .package(url: "https://github.com/luoxiu/Chalk", from: "0.0.4"),
        .package(url: "https://github.com/kylef/Commander", from: "0.8.0"),
        .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
        .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
@@ -76,7 +76,7 @@ let package = Package(
             name: "SwiftyMockyCLICore",
             dependencies: [
                 "ShellOut",
-                "Crayon",
+                "Chalk",
                 "PathKit",
                 "Yams",
             ],

--- a/Sources/SwiftyMockyCLICore/Commands/GenerationController.swift
+++ b/Sources/SwiftyMockyCLICore/Commands/GenerationController.swift
@@ -3,7 +3,6 @@ import ShellOut
 import PathKit
 import Commander
 import Yams
-import Crayon
 
 public protocol GenerationCommand: AutoMockable {
 

--- a/Sources/SwiftyMockyCLICore/Commands/MacOS/MigrationController.swift
+++ b/Sources/SwiftyMockyCLICore/Commands/MacOS/MigrationController.swift
@@ -3,7 +3,6 @@ import Yams
 import PathKit
 import Commander
 import XcodeProj
-import Crayon
 
 // MARK: - Migration
 

--- a/Sources/SwiftyMockyCLICore/Commands/MacOS/ProjectSetupController.swift
+++ b/Sources/SwiftyMockyCLICore/Commands/MacOS/ProjectSetupController.swift
@@ -3,7 +3,7 @@ import Yams
 import PathKit
 import Commander
 import XcodeProj
-import Crayon
+import Chalk
 
 // MARK: - Project Setup
 
@@ -47,7 +47,7 @@ public class ProjectSetupController {
         .forEach {
             let exists = $1.mockName != nil
             let prefix = "\(exists ? "❕":"☑️ ") \($0 + 1))"
-            let infix = "\(crayon.bold.on($1.name))"
+            let infix = "\(ck.bold.on($1.name))"
             let suffix = exists ? " - already defined in \'\($1.mockName!)\'" : ""
             Message.just("\(prefix) \(infix) \(suffix)")
         }
@@ -119,19 +119,19 @@ public class ProjectSetupController {
             Message.actionHeader("\(target.name) - adding Mock configuration...")
         }
 
-        Message.infoPoint("Targets set to: \(crayon.bold.on(target.name))")
+        Message.infoPoint("Targets set to: \(ck.bold.on(target.name))")
 
         let output = "./" + defaultOutput(for: target).string
-        Message.infoPoint("Default output set to: \(crayon.bold.on(output))")
+        Message.infoPoint("Default output set to: \(ck.bold.on(output))")
 
         let sources = "./" + defaultSources(for: target).string
-        Message.infoPoint("Default sources directory: \(crayon.bold.on(sources))")
+        Message.infoPoint("Default sources directory: \(ck.bold.on(sources))")
 
         let testable = defaultTestable(for: target)
-        Message.infoPoint("Default testable module: \(crayon.bold.on(testable.joined(separator: ",")))")
+        Message.infoPoint("Default testable module: \(ck.bold.on(testable.joined(separator: ",")))")
 
         let imports = defaultImports(for: target)
-        Message.infoPoint("Default testable module: \(crayon.bold.on(imports.joined(separator: ",")))")
+        Message.infoPoint("Default testable module: \(ck.bold.on(imports.joined(separator: ",")))")
 
         guard force || !mockfile.isSetup(target: target) else {
             throw MockyError.overrideWarning

--- a/Sources/SwiftyMockyCLICore/InteractiveOptions/AddingOption.swift
+++ b/Sources/SwiftyMockyCLICore/InteractiveOptions/AddingOption.swift
@@ -32,9 +32,9 @@ enum AddingOption: RawRepresentable, SelectableOption {
     var title: String {
         switch self {
         case .only(let value):
-            return ck.underline.on("\(value)") + ""
+            return ck.underline.on("\(value)").string
         default:
-            return ck.underline.on("\(rawValue.first!)".uppercased()) + "\(rawValue.dropFirst())"
+            return ck.underline.on("\(rawValue.first!)".uppercased()).string + "\(rawValue.dropFirst())"
         }
     }
 

--- a/Sources/SwiftyMockyCLICore/InteractiveOptions/AddingOption.swift
+++ b/Sources/SwiftyMockyCLICore/InteractiveOptions/AddingOption.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Crayon
+import Chalk
 
 // MARK: - Setup policy
 
@@ -32,9 +32,9 @@ enum AddingOption: RawRepresentable, SelectableOption {
     var title: String {
         switch self {
         case .only(let value):
-            return crayon.underline.on("\(value)") + ""
+            return ck.underline.on("\(value)") + ""
         default:
-            return crayon.underline.on("\(rawValue.first!)".uppercased()) + "\(rawValue.dropFirst())"
+            return ck.underline.on("\(rawValue.first!)".uppercased()) + "\(rawValue.dropFirst())"
         }
     }
 

--- a/Sources/SwiftyMockyCLICore/InteractiveOptions/Booloption.swift
+++ b/Sources/SwiftyMockyCLICore/InteractiveOptions/Booloption.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Crayon
+import Chalk
 
 public enum BoolOption: RawRepresentable, SelectableOption {
     public typealias RawValue = String
@@ -14,7 +14,7 @@ public enum BoolOption: RawRepresentable, SelectableOption {
         }
     }
     public var title: String {
-        return crayon.underline.on("\(rawValue.first!)".uppercased()) + "\(rawValue.dropFirst())"
+        return ck.underline.on("\(rawValue.first!)".uppercased()) + "\(rawValue.dropFirst())"
     }
 
     public init?(rawValue: String) {

--- a/Sources/SwiftyMockyCLICore/InteractiveOptions/Booloption.swift
+++ b/Sources/SwiftyMockyCLICore/InteractiveOptions/Booloption.swift
@@ -14,7 +14,7 @@ public enum BoolOption: RawRepresentable, SelectableOption {
         }
     }
     public var title: String {
-        return ck.underline.on("\(rawValue.first!)".uppercased()) + "\(rawValue.dropFirst())"
+        return ck.underline.on("\(rawValue.first!)".uppercased()).string + "\(rawValue.dropFirst())"
     }
 
     public init?(rawValue: String) {

--- a/Sources/SwiftyMockyCLICore/InteractiveOptions/ProjectOption.swift
+++ b/Sources/SwiftyMockyCLICore/InteractiveOptions/ProjectOption.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Crayon
+import Chalk
 import PathKit
 
 public struct ProjectPathOption: RawRepresentable, SelectableOption {
@@ -10,7 +10,7 @@ public struct ProjectPathOption: RawRepresentable, SelectableOption {
     public var rawValue: String
     public var title: String {
         if rawValue == ProjectPathOption.projects.first?.string {
-            let formatted = crayon.underline.on("\(Path(rawValue).lastComponentWithoutExtension)")
+            let formatted = ck.underline.on("\(Path(rawValue).lastComponentWithoutExtension)")
             return "\(formatted)"
         }
         return Path(rawValue).lastComponentWithoutExtension

--- a/Sources/SwiftyMockyCLICore/InteractiveOptions/SelectableOption.swift
+++ b/Sources/SwiftyMockyCLICore/InteractiveOptions/SelectableOption.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Crayon
 
 public protocol SelectableOption: RawRepresentable {
     var title: String { get }

--- a/Sources/SwiftyMockyCLICore/Utils/Message.swift
+++ b/Sources/SwiftyMockyCLICore/Utils/Message.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Crayon
+import Chalk
 
 public enum Message {
     public static var indentString = "  "
@@ -40,45 +40,45 @@ public enum Message {
     public static func header(_ message: String) {
         empty()
         count += 1
-        let styled = crayon.bold.on("\(count). \(message)")
+        let styled = ck.bold.on("\(count). \(message)")
         just("\(styled)")
     }
 
     public static func subheader(_ message: String) {
-        let styled = crayon.bold.on(message)
+        let styled = ck.bold.on(message)
         just("\(styled)")
     }
 
     public static func actionHeader(_ message: String) {
-        let styled = crayon.bold.bg(.darkGreen).whiteBright.on(message)
+        let styled = ck.bold.bg(.darkGreen).whiteBright.on(message)
         just("\(styled)")
     }
 
     public static func infoPoint(_ message: String) {
-        let styled = crayon.bold.on(" -> \(message)")
+        let styled = ck.bold.on(" -> \(message)")
         just("\(styled)")
     }
 
     public static func success(_ message: String) {
-        just("✅  \(crayon.greenBright.on(message))")
+        just("✅  \(ck.greenBright.on(message))")
     }
 
     public static func ok(_ message: String) {
-        let styled = crayon.greenBright.on(" +  \(message)")
+        let styled = ck.greenBright.on(" +  \(message)")
         just("\(styled)")
     }
 
     public static func nok(_ message: String) {
-        let styled = crayon.red.on(" -  \(message)")
+        let styled = ck.red.on(" -  \(message)")
         just("\(styled)")
     }
 
     public static func failure(_ message: String) {
-        just("❌  \(crayon.bold.red.on(message))")
+        just("❌  \(ck.bold.red.on(message))")
     }
 
     public static func warning(_ message: String) {
-        just("⚠️  \(crayon.bold.yellow.on(message))")
+        just("⚠️  \(ck.bold.yellow.on(message))")
     }
 
     public static func resolutions(_ messages: String..., title: String = "Possible solutions:") {
@@ -87,25 +87,25 @@ public enum Message {
 
     public static func resolutions(array messages: [String], title: String = "Possible solutions:") {
         indent()
-        just("\(crayon.underline.gray.on(title))")
+        just("\(ck.underline.gray.on(title))")
         messages.forEach { 
-            let styled = crayon.gray.on(" - \($0)")
+            let styled = ck.gray.on(" - \($0)")
             just("\(styled)")
         }
         unindent()
     }
 
     public static func hint(_ message: String) {
-        just("\(crayon.underline.gray.on(message))")
+        just("\(ck.underline.gray.on(message))")
     }
 
     // MARK: - Misc
 
     public static func swiftyMockyLabel(_ message: String) {
         let bar = String(repeating: "═", count: message.count + 2)
-        print(crayon.bold.on("╔\(bar)╗"))
-        print(crayon.bold.on("║ \(message) ║"))
-        print(crayon.bold.on("╚\(bar)╝"))
+        print(ck.bold.on("╔\(bar)╗"))
+        print(ck.bold.on("║ \(message) ║"))
+        print(ck.bold.on("╚\(bar)╝"))
         print("")
     }
 }

--- a/Sources/Templates/Mock.swifttemplate
+++ b/Sources/Templates/Mock.swifttemplate
@@ -1341,7 +1341,10 @@ class VariableWrapper {
     var readonly: Bool { return variable.writeAccess.isEmpty }
     var privatePrototypeName: String { return "__p_\(variable.name)".replacingOccurrences(of: "`", with: "") }
     var casesCount: Int { return readonly ? 1 : 2 }
-
+    var accessModifier: String {
+        guard variable.type?.accessLevel != "internal" else { return "" }
+        return "public "
+    }
     let deprecatedMessage = "Using setters on readonly variables is deprecated, and will be removed in 3.1. Use Given to define stubbed property return value."
     var noStubDefinedMessage: String { return "\(scope) - stub value for \(variable.name) was not defined" }
 
@@ -1362,7 +1365,7 @@ class VariableWrapper {
     var prototype: String {
         let staticModifier = variable.isStatic ? "static " : ""
 
-        return "public \(staticModifier)var \(variable.name): \(variable.typeName.name) {" +
+        return "\(accessModifier)\(staticModifier)var \(variable.name): \(variable.typeName.name) {" +
             "\(getter)" +
             "\(setter)" +
         "\n\t}"
@@ -1413,7 +1416,7 @@ class VariableWrapper {
 
     // Given
     func givenConstructorName(prefix: String = "") -> String {
-        return "public static func \(variable.name)(getter defaultValue: \(TypeWrapper(variable.typeName).stripped)...) -> \(prefix)PropertyStub"
+        return "\(accessModifier)static func \(variable.name)(getter defaultValue: \(TypeWrapper(variable.typeName).stripped)...) -> \(prefix)PropertyStub"
     }
 
     func givenConstructor(prefix: String = "") -> String {


### PR DESCRIPTION
As explained in #248, SPM currently resolves Chalk to 0.0.7 which includes breaking changes in its public API. This leads to `swift build` and `swift run` failing for the executable's target `swiftymocky`. 

As part of this PR, I'm also suggesting to pull in changes that are currently only in the master branch into the develop branch. I have no clue why those are not yet in develop, maybe @KKirsten and @Przemyslaw-Wosko can enlighten us. 😄 

The `ShellOut`, `Commander`, `Rainbow` and  `XcodeProj` dependencies have been updated by re-resolving the dependencies. We could pin them to their previous versions but as the build is not failing and the tests succeed, I assume everything is fine. 