### PR TITLE
Conditionally import XCTest

### DIFF
--- a/Sources/SwiftyMocky/CustomAssertions.swift
+++ b/Sources/SwiftyMocky/CustomAssertions.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 
 /// Allows to verify if error was thrown, and if it is of given type.
@@ -42,3 +43,4 @@ public func XCTAssertThrowsError<T, E>(
         XCTAssertTrue((errorThrown as? E) == error, typeMessage, file: file, line: line)
     }
 }
+#endif

--- a/Sources/SwiftyMocky/SwiftyMockyTestObserver.swift
+++ b/Sources/SwiftyMocky/SwiftyMockyTestObserver.swift
@@ -1,4 +1,5 @@
 import Foundation
+#if canImport(XCTest)
 import XCTest
 
 /// Used for observing tests and handling internal library errors.
@@ -65,6 +66,7 @@ public class SwiftyMockyTestObserver: NSObject, XCTestObservation {
         return testCase.name.components(separatedBy: " ")[1].components(separatedBy: "]").first
     }
 }
+#endif
 
 /// [Internal] Internal dependency that looks for line of test case, that caused test failure.
 private class FilesExlorer {


### PR DESCRIPTION
Found a couple instances where we weren't conditionally importing XCTest.