### PR TITLE
Update Sourcery to 1.0.2

### DIFF
--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,2 @@
 MakeAWishFoundation/SwiftyMocky-CLI@4.0.1
-krzysztofzablocki/Sourcery@1.0.0
+krzysztofzablocki/Sourcery@1.0.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Sourcery (1.0.0)
-  - SwiftyMocky (4.0.1):
-    - Sourcery (>= 0.18)
+  - Sourcery (1.0.2)
+  - SwiftyMocky (4.0.2):
+    - Sourcery (~> 1.0.0)
 
 DEPENDENCIES:
   - SwiftyMocky (from `./`)
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  Sourcery: e0e8658a1ce6d9f475156ad3ffce4c68f1261b3e
-  SwiftyMocky: 8c701b84442e63efba60cd0f7838cfbbeceed9c9
+  Sourcery: e8951e8759ef6a3a0cce412db64832dd23343041
+  SwiftyMocky: 6b5242265b13df3096a0acbd3d493bad4443ec8c
 
 PODFILE CHECKSUM: c5b363f6fe9e513e1d6cf9bbd52b93f5e914d9aa
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1

--- a/SwiftyMocky.podspec
+++ b/SwiftyMocky.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SwiftyMocky'
-  s.version          = '4.0.1'
+  s.version          = '4.0.2'
   s.summary          = 'Unit testing library for Swift, with mock generation. Adds a set of handy methods, simplifying testing.'
   s.description      = <<-DESC
 Library that uses metaprogramming technique to generate mocks based on sources, that makes testing for Swift Mockito-like.
@@ -22,7 +22,7 @@ Library that uses metaprogramming technique to generate mocks based on sources, 
   s.resources = '{Sources/SwiftyMocky/Mock.swifttemplate,get_sourcery.sh}'
   s.frameworks = 'Foundation'
   s.weak_framework = "XCTest"
-  s.dependency 'Sourcery', '>= 1.0'
+  s.dependency 'Sourcery', '~> 1.0.0'
   s.pod_target_xcconfig = {
       'APPLICATION_EXTENSION_API_ONLY' => 'YES',
       'ENABLE_BITCODE' => 'NO',

--- a/SwiftyPrototype.podspec
+++ b/SwiftyPrototype.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SwiftyPrototype'
-  s.version          = '4.0.1'
+  s.version          = '4.0.2'
   s.summary          = 'Prototyping/Faking library for Swift, with code generation. Auto-generates fakes/prototypes based on protocol definitions.'
   s.description      = <<-DESC
 Library that uses metaprogramming technique to generate fakes/prototypes based on sources, makin it easier to prototype app.
@@ -21,5 +21,5 @@ Library that uses metaprogramming technique to generate fakes/prototypes based o
   s.source_files = 'Sources/SwiftyPrototype/**/*.swift'
   s.resources = '{Sources/SwiftyPrototype/Prototype.swifttemplate,get_sourcery.sh}'
   s.frameworks = 'Foundation'
-  s.dependency 'Sourcery', '>= 1.0'
+  s.dependency 'Sourcery', '~> 1.0.0'
 end


### PR DESCRIPTION
Sourcery 1.0.0 doesn't support Xcode 12 properly, I'm getting the following errors:

```shell
Showing All Messages
🌱 Finding latest version of SwiftyMocky-CLI
🌱 Running swiftymocky 4.0.1...
🌱 Cloning Sourcery 1.0.0
🌱 Resolving package

╔════════════════════════╗
║ SwiftyMocky CLI v4.0.1 ║
╚════════════════════════╝

Running at: <path>

Using template from CLI

Processing mock: CoreTests ...

❌  Error: ShellOut encountered an error

Status code: 1

Message: "/private/var/folders/7h/4x9jfdt97x549xg703jx3q000000gn/T/mint/github.com_krzysztofzablocki_Sourcery: error: manifest parse error(s):

<path>/Core/<unknown>:1:1: using sysroot for 'iPhoneSimulator' but targeting 'MacOSX'

🌱 Encountered error during "swift package resolve". Use --verbose to see full output
🌱  Failed to resolve Sourcery 1.0.0 with SPM"
Output: "🌱 Cloning Sourcery 1.0.0
🌱 Resolving package"
<path>/Core/<unknown>:1:1: unable to load standard library for target 'x86_64-apple-macosx10.15'
```

In 1.0.2, these errors are fixed. 

(I'd normally open the PR pointing to `develop`, however it seems to be behind `master`.)