### PR TITLE
Update deprecated XCTest linking

### DIFF
--- a/SwiftyMocky.podspec
+++ b/SwiftyMocky.podspec
@@ -26,7 +26,7 @@ Library that uses metaprogramming technique to generate mocks based on sources, 
   s.pod_target_xcconfig = {
       'APPLICATION_EXTENSION_API_ONLY' => 'YES',
       'ENABLE_BITCODE' => 'NO',
-      'OTHER_LDFLAGS' => '-weak-lXCTestSwiftSupport -Xlinker -no_application_extension',
+      'OTHER_LDFLAGS' => '$(inherited) -weak-lXCTestSwiftSupport -Xlinker -no_application_extension',
       'OTHER_SWIFT_FLAGS' => '$(inherited) -suppress-warnings',
       'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"',
       'DEFINES_MODULE' => 'YES'

--- a/SwiftyMocky.podspec
+++ b/SwiftyMocky.podspec
@@ -26,7 +26,7 @@ Library that uses metaprogramming technique to generate mocks based on sources, 
   s.pod_target_xcconfig = {
       'APPLICATION_EXTENSION_API_ONLY' => 'YES',
       'ENABLE_BITCODE' => 'NO',
-      'OTHER_LDFLAGS' => '$(inherited) -weak-lswiftXCTest -Xlinker -no_application_extension',
+      'OTHER_LDFLAGS' => '-weak-lXCTestSwiftSupport -Xlinker -no_application_extension',
       'OTHER_SWIFT_FLAGS' => '$(inherited) -suppress-warnings',
       'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"',
       'DEFINES_MODULE' => 'YES'

--- a/SwiftyMocky.xcodeproj/project.pbxproj
+++ b/SwiftyMocky.xcodeproj/project.pbxproj
@@ -2331,7 +2331,7 @@
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
+					"-weak-lXCTestSwiftSupport",
 				);
 				OTHER_SWIFT_FLAGS = "-DMocky";
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiftymocky.SwiftyMocky;
@@ -2374,7 +2374,7 @@
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
+					"-weak-lXCTestSwiftSupport",
 				);
 				OTHER_SWIFT_FLAGS = "-DMocky";
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiftymocky.SwiftyMocky;


### PR DESCRIPTION
SwiftyMocky is still using `libswiftXCTest.dylib` from XCTest. This has been deprecated in Xcode 11 in favor of `libXCTestSwiftSupport.dylib`. 
In Xcode 12.5 beta 2, `libswiftXCTest.dylib` seems to be removed and the project would not compile.

Deprecation mentioned [here](https://developer.apple.com/documentation/xcode-release-notes/xcode-12_5-beta-release-notes).

Referencing: #277