### PR TITLE
Added swiftLintRules calls to templates

### DIFF
--- a/Sources/SwiftyMocky/Mock.swifttemplate
+++ b/Sources/SwiftyMocky/Mock.swifttemplate
@@ -39,6 +39,10 @@ func stringArray(fromArguments arguments: [String: Any], forKey key: String) -> 
 _%>
 // Generated with SwiftyMocky 4.0.4
 
+<%_ for rule in swiftLintRules(argument) { -%>
+    <%_ %><%= rule %>
+<%_ } -%>
+
 import SwiftyMocky
 import XCTest
 <%# ================================================== IMPORTS -%><%_ -%>

--- a/Sources/SwiftyPrototype/Prototype.swifttemplate
+++ b/Sources/SwiftyPrototype/Prototype.swifttemplate
@@ -39,6 +39,10 @@ func stringArray(fromArguments arguments: [String: Any], forKey key: String) -> 
 _%>
 // Generated with SwiftyPrototype 4.0.4
 
+<%_ for rule in swiftLintRules(argument) { -%>
+    <%_ %><%= rule %>
+<%_ } -%>
+
 import SwiftyPrototype
 <%# ================================================== IMPORTS -%><%_ -%>
     <%_ for projectImport in projectImports(argument) { -%>


### PR DESCRIPTION
There is `excludedSwiftLintRules` config option to add some ignored linter rules, it's [documented](https://github.com/MakeAWishFoundation/SwiftyMocky/blob/master/guides/Legacy.md) however it doesn't work.