### PR TITLE
Release 4.2.0

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ author: Przemysław Wośko, Andrzej Michnia
 author_url: https://girappe.com
 module: SwiftyMocky
 sourcekitten_sourcefile: docs.json
-module_version: 4.1.0
+module_version: 4.2.0
 github_url: https://github.com/MakeAWishFoundation/SwiftyMocky
 copyright: 'Copyright © 2017 MakeAWishFoundation. All rights reserved.'
 readme: guides/Overview.md

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXECUTABLE_NAME = swiftymocky
 REPO = https://github.com/MakeAWishFoundation/SwiftyMocky
-VERSION = 4.1.0
+VERSION = 4.2.0
 
 PREFIX = /usr/local
 INSTALL_PATH = $(PREFIX)/bin/$(EXECUTABLE_NAME)

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Add **SwiftyMocky** to you **Package.swift** dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/MakeAWishFoundation/SwiftyMocky", from: "4.1.0"),
+    .package(url: "https://github.com/MakeAWishFoundation/SwiftyMocky", from: "4.2.0"),
 ]
 ```
 
@@ -385,15 +385,15 @@ SwiftyMocky is available under the MIT license. See the [LICENSE][link-license] 
 
 <!-- Links based on tag -->
 
-[link-docs]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/index.html
-[link-docs-features]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/supported-features.html
-[link-docs-installation]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/installation.html
-[link-docs-installation-carthage]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/installation.html#installation-carthage
-[link-docs-setup]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/setup-in-project.html
+[link-docs]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/index.html
+[link-docs-features]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/supported-features.html
+[link-docs-installation]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/installation.html
+[link-docs-installation-carthage]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/installation.html#installation-carthage
+[link-docs-setup]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/setup-in-project.html
 
 <!-- Assets -->
 
-[logo]: https://raw.githubusercontent.com/MakeAWishFoundation/SwiftyMocky/4.1.0/icon.png
+[logo]: https://raw.githubusercontent.com/MakeAWishFoundation/SwiftyMocky/4.2.0/icon.png
 [example-watcher]: https://raw.githubusercontent.com/MakeAWishFoundation/SwiftyMocky/1.0.0/guides/assets/example-watcher.gif "Example - generation"
 [example-given]: https://raw.githubusercontent.com/MakeAWishFoundation/SwiftyMocky/1.0.0/guides/assets/example-given.gif "Example - given"
 [example-verify]: https://raw.githubusercontent.com/MakeAWishFoundation/SwiftyMocky/1.0.0/guides/assets/example-verify.gif "Example - verify"

--- a/Sources/CLI/Core/Application.swift
+++ b/Sources/CLI/Core/Application.swift
@@ -6,7 +6,7 @@ public class Application {
 
     // MARK: - Properties
 
-    public let version = "4.1.0"
+    public let version = "4.2.0"
     public var pwd = Path(ProcessInfo.processInfo.environment["PWD"] ?? "")
     public var handle: (Error) -> Void = { error in
         switch error {

--- a/Sources/SwiftyMocky/Mock.swifttemplate
+++ b/Sources/SwiftyMocky/Mock.swifttemplate
@@ -37,7 +37,7 @@ func stringArray(fromArguments arguments: [String: Any], forKey key: String) -> 
     }
 }
 _%>
-// Generated with SwiftyMocky 4.1.0
+// Generated with SwiftyMocky 4.2.0
 // Required Sourcery: 1.8.0
 
 <%_ for rule in swiftLintRules(argument) { -%>

--- a/Sources/SwiftyPrototype/Prototype.swifttemplate
+++ b/Sources/SwiftyPrototype/Prototype.swifttemplate
@@ -37,7 +37,7 @@ func stringArray(fromArguments arguments: [String: Any], forKey key: String) -> 
     }
 }
 _%>
-// Generated with SwiftyPrototype 4.1.0
+// Generated with SwiftyPrototype 4.2.0
 // Required Sourcery: 1.8.0
 
 <%_ for rule in swiftLintRules(argument) { -%>

--- a/SwiftyMocky-Runtime/Info.plist
+++ b/SwiftyMocky-Runtime/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.1.0</string>
+	<string>4.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/SwiftyMocky-Tests/iOS/Mocks/Mock.15.generated.swift
+++ b/SwiftyMocky-Tests/iOS/Mocks/Mock.15.generated.swift
@@ -2,7 +2,7 @@
 // DO NOT EDIT
 
 
-// Generated with SwiftyMocky 4.1.0
+// Generated with SwiftyMocky 4.2.0
 // Required Sourcery: 1.8.0
 
 

--- a/SwiftyMocky-Tests/iOS/Mocks/Mock.generated.swift
+++ b/SwiftyMocky-Tests/iOS/Mocks/Mock.generated.swift
@@ -2,7 +2,7 @@
 // DO NOT EDIT
 
 
-// Generated with SwiftyMocky 4.1.0
+// Generated with SwiftyMocky 4.2.0
 // Required Sourcery: 1.8.0
 
 

--- a/SwiftyMocky-Tests/macOS/Mocks/Mock.generated.swift
+++ b/SwiftyMocky-Tests/macOS/Mocks/Mock.generated.swift
@@ -2,7 +2,7 @@
 // DO NOT EDIT
 
 
-// Generated with SwiftyMocky 4.1.0
+// Generated with SwiftyMocky 4.2.0
 // Required Sourcery: 1.8.0
 
 

--- a/SwiftyMocky-Tests/tvOS/Mocks/Mock.generated.swift
+++ b/SwiftyMocky-Tests/tvOS/Mocks/Mock.generated.swift
@@ -2,7 +2,7 @@
 // DO NOT EDIT
 
 
-// Generated with SwiftyMocky 4.1.0
+// Generated with SwiftyMocky 4.2.0
 // Required Sourcery: 1.8.0
 
 

--- a/SwiftyMocky.podspec
+++ b/SwiftyMocky.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SwiftyMocky'
-  s.version          = '4.1.0'
+  s.version          = '4.2.0'
   s.summary          = 'Unit testing library for Swift, with mock generation. Adds a set of handy methods, simplifying testing.'
   s.description      = <<-DESC
 Library that uses metaprogramming technique to generate mocks based on sources, that makes testing for Swift Mockito-like.

--- a/SwiftyPrototype.podspec
+++ b/SwiftyPrototype.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SwiftyPrototype'
-  s.version          = '4.1.0'
+  s.version          = '4.2.0'
   s.summary          = 'Prototyping/Faking library for Swift, with code generation. Auto-generates fakes/prototypes based on protocol definitions.'
   s.description      = <<-DESC
 Library that uses metaprogramming technique to generate fakes/prototypes based on sources, makin it easier to prototype app.

--- a/Templates/Header-Mock.swifttemplate
+++ b/Templates/Header-Mock.swifttemplate
@@ -1,4 +1,4 @@
-// Generated with SwiftyMocky 4.1.0
+// Generated with SwiftyMocky 4.2.0
 // Required Sourcery: 1.8.0
 
 <%_ for rule in swiftLintRules(argument) { -%>

--- a/Templates/Header-Prototype.swifttemplate
+++ b/Templates/Header-Prototype.swifttemplate
@@ -1,4 +1,4 @@
-// Generated with SwiftyPrototype 4.1.0
+// Generated with SwiftyPrototype 4.2.0
 // Required Sourcery: 1.8.0
 
 <%_ for rule in swiftLintRules(argument) { -%>

--- a/Tests/SwiftyMockyCLICoreTests/Mock.generated.swift
+++ b/Tests/SwiftyMockyCLICoreTests/Mock.generated.swift
@@ -2,7 +2,7 @@
 // DO NOT EDIT
 
 
-// Generated with SwiftyMocky 4.1.0
+// Generated with SwiftyMocky 4.2.0
 // Required Sourcery: 1.8.0
 
 

--- a/Tests/SwiftyMockyTests/Mock.generated.swift
+++ b/Tests/SwiftyMockyTests/Mock.generated.swift
@@ -2,7 +2,7 @@
 // DO NOT EDIT
 
 
-// Generated with SwiftyMocky 4.1.0
+// Generated with SwiftyMocky 4.2.0
 // Required Sourcery: 1.8.0
 
 

--- a/guides/Installation.md
+++ b/guides/Installation.md
@@ -86,7 +86,7 @@ Add **SwiftyMocky** to you **Package.swift** dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/MakeAWishFoundation/SwiftyMocky", from: "4.1.0"),
+    .package(url: "https://github.com/MakeAWishFoundation/SwiftyMocky", from: "4.2.0"),
 ]
 ```
 

--- a/guides/Overview.md
+++ b/guides/Overview.md
@@ -1,4 +1,4 @@
-# SwiftyMocky 4.1.0
+# SwiftyMocky 4.2.0
 
 # ![logo][logo]
 
@@ -113,7 +113,7 @@ Add **SwiftyMocky** to you **Package.swift** dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/MakeAWishFoundation/SwiftyMocky", from: "4.1.0"),
+    .package(url: "https://github.com/MakeAWishFoundation/SwiftyMocky", from: "4.2.0"),
 ]
 ```
 
@@ -357,28 +357,28 @@ SwiftyMocky is available under the MIT license. See the [LICENSE][link-license] 
 
 <!-- Links -->
 
-[link-guides-installation]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/setup-in-project.html
-[link-guides-contents]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/contents.html
-[link-guides-examples]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/examples.html
-[link-changelog]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/changelog.html
+[link-guides-installation]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/setup-in-project.html
+[link-guides-contents]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/contents.html
+[link-guides-examples]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/examples.html
+[link-changelog]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/changelog.html
 
-[link-guides-cli]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/command-line-interface.html
-[link-guides-cli-migration]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/command-line-interface.html#migration
-[link-guides-cli-legacy]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/legacy.html
-[link-guides-cli-generate]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/command-line-interface.html#generate
-[link-guides-mockfile]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/mockfile.html
+[link-guides-cli]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/command-line-interface.html
+[link-guides-cli-migration]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/command-line-interface.html#migration
+[link-guides-cli-legacy]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/legacy.html
+[link-guides-cli-generate]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/command-line-interface.html#generate
+[link-guides-mockfile]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/mockfile.html
 
 <!-- Links based on tag -->
 
-[link-docs]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/index.html
-[link-docs-features]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/supported-features.html
-[link-docs-installation]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/installation.html
-[link-docs-installation-carthage]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/installation.html#installation-carthage
-[link-docs-setup]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.1.0/docs/setup-in-project.html
+[link-docs]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/index.html
+[link-docs-features]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/supported-features.html
+[link-docs-installation]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/installation.html
+[link-docs-installation-carthage]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/installation.html#installation-carthage
+[link-docs-setup]: https://rawcdn.githack.com/MakeAWishFoundation/SwiftyMocky/4.2.0/docs/setup-in-project.html
 
 <!-- Assets -->
 
-[logo]: https://raw.githubusercontent.com/MakeAWishFoundation/SwiftyMocky/4.1.0/icon.png
+[logo]: https://raw.githubusercontent.com/MakeAWishFoundation/SwiftyMocky/4.2.0/icon.png
 [example-watcher]: https://raw.githubusercontent.com/MakeAWishFoundation/SwiftyMocky/3.2.0/guides/assets/example-watcher.gif "Example - generation"
 [example-given]: https://raw.githubusercontent.com/MakeAWishFoundation/SwiftyMocky/3.2.0/guides/assets/example-given.gif "Example - given"
 [example-verify]: https://raw.githubusercontent.com/MakeAWishFoundation/SwiftyMocky/3.2.0/guides/assets/example-verify.gif "Example - verify"


### PR DESCRIPTION
Releases the fix for #306. 

This MR ran `rake version 4.1.0 4.2.0` and `rake test` locally. Consider it release preparation, as I don't actually have rights to release anything. :)  