### PR TITLE
Added support for root typealiases

### DIFF
--- a/Sources/SwiftyMocky/Mock.swifttemplate
+++ b/Sources/SwiftyMocky/Mock.swifttemplate
@@ -239,6 +239,16 @@ class Helpers {
             return []
         }
     }
+    /// Extract all root typealiases from "annotations"
+    static func extractRootTypealiases(from annotated: SourceryRuntime.Annotated) -> [String] {
+        if let types = annotated.annotations["roottypealias"] as? [String] {
+            return types.reversed()
+        } else if let type = annotated.annotations["root-typealias"] as? String {
+            return [type]
+        } else {
+            return []
+        }
+    }
     static func extractGenericsList(_ associatedTypes: [String]?) -> [String] {
         return associatedTypes?.flatMap {
             split($0, byFirstOccurenceOf: " where ").0.replacingOccurrences(of: " ", with: "").characters.split(separator: ":").map(String.init).first
@@ -1613,6 +1623,7 @@ _%>
     let associatedTypes: [String]? = Helpers.extractAssociatedTypes(from: aProtocol)
     let attributes: String = Helpers.extractAttributes(from: type.attributes)
     let typeAliases: [String] = Helpers.extractTypealiases(from: aProtocol)
+    let rootTypeAliases: [String] = Helpers.extractRootTypealiases(from: aProtocol)
     let genericTypesModifier: String = Helpers.extractGenericTypesModifier(associatedTypes)
     let genericTypesConstraints: String = Helpers.extractGenericTypesConstraints(associatedTypes)
     let allSubscripts = aProtocol.allSubscripts
@@ -1632,6 +1643,9 @@ _%>
     let conformsToMock = !allMethods.isEmpty || !allVariables.isEmpty -%><%_ -%><%_ -%>
 <%_ if autoMockable { -%>
 // MARK: - <%= type.name %>
+<%_ for rootTypeAlias in rootTypeAliases { -%>
+public typealias <%= rootTypeAlias %>
+<%_ } %> <%_ -%>
 <%= attributes %>
 <%= accessModifier %> class <%= type.name %><%= mockTypeName %><%= genericTypesModifier %>:<%= inheritFromNSObject ? " NSObject," : "" %> <%= type.name %>, Mock<%= conformsToStaticMock ? ", StaticMock" : "" %><%= genericTypesConstraints %> {
     public init(sequencing sequencingPolicy: SequencingPolicy = .lastWrittenResolvedFirst, stubbing stubbingPolicy: StubbingPolicy = .wrap, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
Mock template was customised to add single feature, which I named `root-typealiases`

Root typealiases are placed in root of the resulting file and are NOT nested inside type (as typealiases do).
They are meant to solve problem partially described in https://github.com/MakeAWishFoundation/SwiftyMocky/issues/184
Problem occurs when mock is generated for protocol name, which clashes with type from another library.
Since there is no concept of module in `Sourcery/SwiftyMocky`, compiler gets confused which type should be used for inheritance, for example:


### Typealias example:

Our module:
```
    //sourcery: root-typealias = "Feature = MyModule.Feature"
    protocol Feature: AutoMockable {}
```

Another module:
```
    public struct Feature {}
```

Resulting `Mock.generated.swift`:
```
    open class FeatureMock: Feature, Mock { <--- 'Feature' is ambiguous for type lookup in this context
        public typealias Feature = MyModule.Feature
    } 
```

In this implementation this problem can be fixed by adding annotation for Feature protocol, like this:
```
    //sourcery: root-typealias = "Feature = MyModule.Feature"
    protocol Feature: AutoMockable {}
```

Resulting `Mock.generated.swift`:
```
    public typealias Feature = MyModule.Feature
    open class FeatureMock: Feature, Mock {}  <--- No ambiguity for type lookup in this context
```