### PR TITLE
Removed characters from Mock.swifttemplate since it's obsolete in Swift 5.0

### DIFF
--- a/Sources/SwiftyMocky/Mock.swifttemplate
+++ b/Sources/SwiftyMocky/Mock.swifttemplate
@@ -241,7 +241,7 @@ class Helpers {
     }
     static func extractGenericsList(_ associatedTypes: [String]?) -> [String] {
         return associatedTypes?.flatMap {
-            split($0, byFirstOccurenceOf: " where ").0.replacingOccurrences(of: " ", with: "").characters.split(separator: ":").map(String.init).first
+            split($0, byFirstOccurenceOf: " where ").0.replacingOccurrences(of: " ", with: "").split(separator: ":").map(String.init).first
         }.map { "\($0)" } ?? []
     }
     static func extractGenericTypesModifier(_ associatedTypes: [String]?) -> String {
@@ -253,9 +253,9 @@ class Helpers {
         guard let all = associatedTypes else { return "" }
         let constraints = all.flatMap { t -> String? in
             let splitted = split(t, byFirstOccurenceOf: " where ")
-            let constraint = splitted.0.replacingOccurrences(of: " ", with: "").characters.split(separator: ":").map(String.init)
+            let constraint = splitted.0.replacingOccurrences(of: " ", with: "").split(separator: ":").map(String.init)
             guard constraint.count == 2 else { return nil }
-            let adopts = constraint[1].characters.split(separator: ",").map(String.init)
+            let adopts = constraint[1].split(separator: ",").map(String.init)
             var mapped = adopts.map { "\(constraint[0]): \($0)" }
             if !splitted.1.isEmpty {
                 mapped.append(splitted.1)
@@ -1146,7 +1146,7 @@ class MethodWrapper {
         genPart.removeFirst()
         genPart.removeLast()
 
-        let parts = genPart.replacingOccurrences(of: " ", with: "").characters.split(separator: ",").map(String.init)
+        let parts = genPart.replacingOccurrences(of: " ", with: "").split(separator: ",").map(String.init)
         return parts.map { stripGenPart(part: $0) }
     }
 
@@ -1161,7 +1161,7 @@ class MethodWrapper {
         genPart.removeFirst()
         genPart.removeLast()
 
-        let parts = genPart.replacingOccurrences(of: " ", with: "").characters.split(separator: ",").map(String.init)
+        let parts = genPart.replacingOccurrences(of: " ", with: "").split(separator: ",").map(String.init)
         return parts.filter {
             let components = $0.components(separatedBy: ":")
             return (components.count == 2 || !filterSingle) && generics.contains(components[0])
@@ -1183,7 +1183,7 @@ class MethodWrapper {
     }
 
     private func stripGenPart(part: String) -> String {
-        return part.characters.split(separator: ":").map(String.init).first!
+        return part.split(separator: ":").map(String.init).first!
     }
 
     private func returnTypeStripped(_ method: SourceryRuntime.Method, type: Bool = false) -> String {


### PR DESCRIPTION
To fix the compilation issues that arise from using the file `Mock.swifttemplate` in Swift 5.0, I have proceeded with removing the property `.characters` from the file.

With this property, we get the following kind of errors:
```
/private/var/folders/21/8dtt1gkn5175rwk038fjbv300000gp/T/SwiftTemplate/2.1.3/Sources/SwiftTemplate/main.swift:1192:21: error: 'characters' is unavailable: Please use String directly
        return part.characters.split(separator: ":").map(String.init).first!
                    ^~~~~~~~~~
Swift.String:5:16: note: 'characters' was obsoleted in Swift 5.0
    public var characters: String { get set }
               ^
error: fatalError
```

String doesn't have the property `characters` anymore: https://developer.apple.com/documentation/swift/string/1540072-characters