### PR TITLE
Xcode 16 fixes

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -8,14 +8,14 @@ on:
       - master
 jobs:
   SwiftyMocky-Tests:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '13.2.1'
+          xcode-version: '15.4'
       - name: Prepare for tests
         run: |
           rake pods

--- a/Sources/SwiftyMocky/Mock.swifttemplate
+++ b/Sources/SwiftyMocky/Mock.swifttemplate
@@ -241,7 +241,7 @@ class Helpers {
     }
     static func extractGenericsList(_ associatedTypes: [String]?) -> [String] {
         return associatedTypes?.flatMap {
-            split($0, byFirstOccurenceOf: " where ").0.replacingOccurrences(of: " ", with: "").characters.split(separator: ":").map(String.init).first
+            split($0, byFirstOccurenceOf: " where ").0.replacingOccurrences(of: " ", with: "").split(separator: ":").map(String.init).first
         }.map { "\($0)" } ?? []
     }
     static func extractGenericTypesModifier(_ associatedTypes: [String]?) -> String {
@@ -253,9 +253,9 @@ class Helpers {
         guard let all = associatedTypes else { return "" }
         let constraints = all.flatMap { t -> String? in
             let splitted = split(t, byFirstOccurenceOf: " where ")
-            let constraint = splitted.0.replacingOccurrences(of: " ", with: "").characters.split(separator: ":").map(String.init)
+            let constraint = splitted.0.replacingOccurrences(of: " ", with: "").split(separator: ":").map(String.init)
             guard constraint.count == 2 else { return nil }
-            let adopts = constraint[1].characters.split(separator: ",").map(String.init)
+            let adopts = constraint[1].split(separator: ",").map(String.init)
             var mapped = adopts.map { "\(constraint[0]): \($0)" }
             if !splitted.1.isEmpty {
                 mapped.append(splitted.1)
@@ -1146,7 +1146,7 @@ class MethodWrapper {
         genPart.removeFirst()
         genPart.removeLast()
 
-        let parts = genPart.replacingOccurrences(of: " ", with: "").characters.split(separator: ",").map(String.init)
+        let parts = genPart.replacingOccurrences(of: " ", with: "").split(separator: ",").map(String.init)
         return parts.map { stripGenPart(part: $0) }
     }
 
@@ -1161,7 +1161,7 @@ class MethodWrapper {
         genPart.removeFirst()
         genPart.removeLast()
 
-        let parts = genPart.replacingOccurrences(of: " ", with: "").characters.split(separator: ",").map(String.init)
+        let parts = genPart.replacingOccurrences(of: " ", with: "").split(separator: ",").map(String.init)
         return parts.filter {
             let components = $0.components(separatedBy: ":")
             return (components.count == 2 || !filterSingle) && generics.contains(components[0])
@@ -1183,7 +1183,7 @@ class MethodWrapper {
     }
 
     private func stripGenPart(part: String) -> String {
-        return part.characters.split(separator: ":").map(String.init).first!
+        return part.split(separator: ":").map(String.init).first!
     }
 
     private func returnTypeStripped(_ method: SourceryRuntime.Method, type: Bool = false) -> String {

--- a/Sources/SwiftyMocky/Parameter+Literals.swift
+++ b/Sources/SwiftyMocky/Parameter+Literals.swift
@@ -2,29 +2,6 @@ import Foundation
 
 // MARK: - ExpressibleByStringLiteral
 
-extension Optional:
-    ExpressibleByStringLiteral,
-    ExpressibleByExtendedGraphemeClusterLiteral,
-    ExpressibleByUnicodeScalarLiteral
-    where Wrapped: ExpressibleByStringLiteral
-{
-    public typealias StringLiteralType = Wrapped.StringLiteralType
-    public typealias ExtendedGraphemeClusterLiteralType = Wrapped.ExtendedGraphemeClusterLiteralType
-    public typealias UnicodeScalarLiteralType = Wrapped.UnicodeScalarLiteralType
-
-    public init(stringLiteral value: StringLiteralType) {
-        self = .some(Wrapped.init(stringLiteral: value))
-    }
-
-    public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
-        self = .some(Wrapped.init(extendedGraphemeClusterLiteral: value))
-    }
-
-    public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
-        self = .some(Wrapped.init(unicodeScalarLiteral: value))
-    }
-}
-
 extension Parameter:
     ExpressibleByStringLiteral,
     ExpressibleByExtendedGraphemeClusterLiteral,
@@ -58,14 +35,6 @@ extension Parameter: ExpressibleByNilLiteral where ValueType: ExpressibleByNilLi
 
 // MARK: - ExpressibleByIntegerLiteral
 
-extension Optional: ExpressibleByIntegerLiteral where Wrapped: ExpressibleByIntegerLiteral {
-    public typealias IntegerLiteralType = Wrapped.IntegerLiteralType
-
-    public init(integerLiteral value: IntegerLiteralType) {
-        self = .some(Wrapped.init(integerLiteral: value))
-    }
-}
-
 extension Parameter: ExpressibleByIntegerLiteral where ValueType: ExpressibleByIntegerLiteral {
     public typealias IntegerLiteralType = ValueType.IntegerLiteralType
 
@@ -76,14 +45,6 @@ extension Parameter: ExpressibleByIntegerLiteral where ValueType: ExpressibleByI
 
 // MARK: - ExpressibleByBooleanLiteral
 
-extension Optional: ExpressibleByBooleanLiteral where Wrapped: ExpressibleByBooleanLiteral {
-    public typealias BooleanLiteralType = Wrapped.BooleanLiteralType
-
-    public init(booleanLiteral value: BooleanLiteralType) {
-        self = .some(Wrapped.init(booleanLiteral: value))
-    }
-}
-
 extension Parameter: ExpressibleByBooleanLiteral where ValueType: ExpressibleByBooleanLiteral {
     public typealias BooleanLiteralType = ValueType.BooleanLiteralType
 
@@ -93,14 +54,6 @@ extension Parameter: ExpressibleByBooleanLiteral where ValueType: ExpressibleByB
 }
 
 // MARK: - ExpressibleByFloatLiteral
-
-extension Optional: ExpressibleByFloatLiteral where Wrapped: ExpressibleByFloatLiteral {
-    public typealias FloatLiteralType = Wrapped.FloatLiteralType
-
-    public init(floatLiteral value: FloatLiteralType) {
-        self = .some(Wrapped.init(floatLiteral: value))
-    }
-}
 
 extension Parameter: ExpressibleByFloatLiteral where ValueType: ExpressibleByFloatLiteral {
     public typealias FloatLiteralType = ValueType.FloatLiteralType
@@ -126,14 +79,6 @@ private extension ExpressibleByArrayLiteral where ArrayLiteralElement: Hashable 
     }
 }
 
-extension Optional: ExpressibleByArrayLiteral where Wrapped: ExpressibleByArrayLiteral {
-    public typealias ArrayLiteralElement = Wrapped.ArrayLiteralElement
-
-    public init(arrayLiteral elements: ArrayLiteralElement...) {
-        self = .some(Wrapped.init(elements))
-    }
-}
-
 extension Parameter: ExpressibleByArrayLiteral where ValueType: ExpressibleByArrayLiteral {
     public typealias ArrayLiteralElement = ValueType.ArrayLiteralElement
 
@@ -148,15 +93,6 @@ private extension ExpressibleByDictionaryLiteral where Key: Hashable {
     init(_ elements: [(Key, Value)]) {
         let value: [Key: Value] = Dictionary.init(uniqueKeysWithValues: elements)
         self = value as! Self  // TODO: Check if can be fixed. For some reason could not use init(arayLiteral elements: ...)
-    }
-}
-
-extension Optional: ExpressibleByDictionaryLiteral where Wrapped: ExpressibleByDictionaryLiteral, Wrapped.Key: Hashable {
-    public typealias Key = Wrapped.Key
-    public typealias Value = Wrapped.Value
-
-    public init(dictionaryLiteral elements: (Key, Value)...) {
-        self = .some(Wrapped.init(elements))
     }
 }
 

--- a/Sources/SwiftyPrototype/Prototype.swifttemplate
+++ b/Sources/SwiftyPrototype/Prototype.swifttemplate
@@ -240,7 +240,7 @@ class Helpers {
     }
     static func extractGenericsList(_ associatedTypes: [String]?) -> [String] {
         return associatedTypes?.flatMap {
-            split($0, byFirstOccurenceOf: " where ").0.replacingOccurrences(of: " ", with: "").characters.split(separator: ":").map(String.init).first
+            split($0, byFirstOccurenceOf: " where ").0.replacingOccurrences(of: " ", with: "").split(separator: ":").map(String.init).first
         }.map { "\($0)" } ?? []
     }
     static func extractGenericTypesModifier(_ associatedTypes: [String]?) -> String {
@@ -252,9 +252,9 @@ class Helpers {
         guard let all = associatedTypes else { return "" }
         let constraints = all.flatMap { t -> String? in
             let splitted = split(t, byFirstOccurenceOf: " where ")
-            let constraint = splitted.0.replacingOccurrences(of: " ", with: "").characters.split(separator: ":").map(String.init)
+            let constraint = splitted.0.replacingOccurrences(of: " ", with: "").split(separator: ":").map(String.init)
             guard constraint.count == 2 else { return nil }
-            let adopts = constraint[1].characters.split(separator: ",").map(String.init)
+            let adopts = constraint[1].split(separator: ",").map(String.init)
             var mapped = adopts.map { "\(constraint[0]): \($0)" }
             if !splitted.1.isEmpty {
                 mapped.append(splitted.1)
@@ -1145,7 +1145,7 @@ class MethodWrapper {
         genPart.removeFirst()
         genPart.removeLast()
 
-        let parts = genPart.replacingOccurrences(of: " ", with: "").characters.split(separator: ",").map(String.init)
+        let parts = genPart.replacingOccurrences(of: " ", with: "").split(separator: ",").map(String.init)
         return parts.map { stripGenPart(part: $0) }
     }
 
@@ -1160,7 +1160,7 @@ class MethodWrapper {
         genPart.removeFirst()
         genPart.removeLast()
 
-        let parts = genPart.replacingOccurrences(of: " ", with: "").characters.split(separator: ",").map(String.init)
+        let parts = genPart.replacingOccurrences(of: " ", with: "").split(separator: ",").map(String.init)
         return parts.filter {
             let components = $0.components(separatedBy: ":")
             return (components.count == 2 || !filterSingle) && generics.contains(components[0])
@@ -1182,7 +1182,7 @@ class MethodWrapper {
     }
 
     private func stripGenPart(part: String) -> String {
-        return part.characters.split(separator: ":").map(String.init).first!
+        return part.split(separator: ":").map(String.init).first!
     }
 
     private func returnTypeStripped(_ method: SourceryRuntime.Method, type: Bool = false) -> String {

--- a/SwiftyMocky-Tests/Shared/Other/ExpressibleByLiteralsTests.swift
+++ b/SwiftyMocky-Tests/Shared/Other/ExpressibleByLiteralsTests.swift
@@ -49,8 +49,8 @@ class ExpressibleByLiteralsTests: XCTestCase {
 
         // Optional
         Given(mock, .methodWithOtionalStringParameter(p: .any, willReturn: 0))
-        Given(mock, .methodWithOtionalStringParameter(p: "a", willReturn: 1))
-        Given(mock, .methodWithOtionalStringParameter(p: "b", willReturn: 2))
+        Given(mock, .methodWithOtionalStringParameter(p: .value("a"), willReturn: 1))
+        Given(mock, .methodWithOtionalStringParameter(p: .value("b"), willReturn: 2))
         Given(mock, .methodWithOtionalStringParameter(p: nil, willReturn: 3))
 
         XCTAssertEqual(mock.methodWithOtionalStringParameter(p: "a"), 1)
@@ -58,11 +58,11 @@ class ExpressibleByLiteralsTests: XCTestCase {
         XCTAssertEqual(mock.methodWithOtionalStringParameter(p: "c"), 0)
         XCTAssertEqual(mock.methodWithOtionalStringParameter(p: nil), 3)
 
-        Verify(mock, .methodWithOtionalStringParameter(p: "a"))
-        Verify(mock, .methodWithOtionalStringParameter(p: "b"))
-        Verify(mock, .methodWithOtionalStringParameter(p: "c"))
+        Verify(mock, .methodWithOtionalStringParameter(p: .value("a")))
+        Verify(mock, .methodWithOtionalStringParameter(p: .value("b")))
+        Verify(mock, .methodWithOtionalStringParameter(p: .value("c")))
         Verify(mock, .methodWithOtionalStringParameter(p: nil))
-        Verify(mock, .never, .methodWithOtionalStringParameter(p: "d"))
+        Verify(mock, .never, .methodWithOtionalStringParameter(p: .value("d")))
         Verify(mock, 4, .methodWithOtionalStringParameter(p: .any))
 
         // Custom
@@ -83,8 +83,8 @@ class ExpressibleByLiteralsTests: XCTestCase {
 
         // Custom Optional
         Given(mock, .methodWithCustomOptionalStringParameter(p: .any, willReturn: 0))
-        Given(mock, .methodWithCustomOptionalStringParameter(p: "a", willReturn: 1))
-        Given(mock, .methodWithCustomOptionalStringParameter(p: "b", willReturn: 2))
+        Given(mock, .methodWithCustomOptionalStringParameter(p: .value("a"), willReturn: 1))
+        Given(mock, .methodWithCustomOptionalStringParameter(p: .value("b"), willReturn: 2))
         Given(mock, .methodWithCustomOptionalStringParameter(p: nil, willReturn: 3))
 
         XCTAssertEqual(mock.methodWithCustomOptionalStringParameter(p: CustomString.a), 1)
@@ -93,11 +93,11 @@ class ExpressibleByLiteralsTests: XCTestCase {
         XCTAssertEqual(mock.methodWithCustomOptionalStringParameter(p: nil), 3)
 
         Verify(mock, 1, .methodWithCustomOptionalStringParameter(p: .value(CustomString.a)))
-        Verify(mock, 1, .methodWithCustomOptionalStringParameter(p: "a"))
-        Verify(mock, .methodWithCustomOptionalStringParameter(p: "b"))
-        Verify(mock, .methodWithCustomOptionalStringParameter(p: "c"))
+        Verify(mock, 1, .methodWithCustomOptionalStringParameter(p: .value("a")))
+        Verify(mock, .methodWithCustomOptionalStringParameter(p: .value("b")))
+        Verify(mock, .methodWithCustomOptionalStringParameter(p: .value("c")))
         Verify(mock, .methodWithCustomOptionalStringParameter(p: nil))
-        Verify(mock, .never, .methodWithCustomOptionalStringParameter(p: "d"))
+        Verify(mock, .never, .methodWithCustomOptionalStringParameter(p: .value("d")))
 
         Verify(mock, 4, .methodWithCustomOptionalStringParameter(p: .any))
     }
@@ -121,8 +121,8 @@ class ExpressibleByLiteralsTests: XCTestCase {
 
         // Custom Optional
         Given(mock, .methodWithCustomOptionalIntParameter(p: .any, willReturn: 0))
-        Given(mock, .methodWithCustomOptionalIntParameter(p: 1, willReturn: 1))
-        Given(mock, .methodWithCustomOptionalIntParameter(p: 2, willReturn: 2))
+        Given(mock, .methodWithCustomOptionalIntParameter(p: .value(1), willReturn: 1))
+        Given(mock, .methodWithCustomOptionalIntParameter(p: .value(2), willReturn: 2))
         Given(mock, .methodWithCustomOptionalIntParameter(p: nil, willReturn: 3))
 
         XCTAssertEqual(mock.methodWithCustomOptionalIntParameter(p: CustomInt.value(1)), 1)
@@ -131,9 +131,9 @@ class ExpressibleByLiteralsTests: XCTestCase {
         XCTAssertEqual(mock.methodWithCustomOptionalIntParameter(p: nil), 3)
 
         Verify(mock, 1, .methodWithCustomOptionalIntParameter(p: .value(CustomInt.zero)))
-        Verify(mock, 1, .methodWithCustomOptionalIntParameter(p: 1))
-        Verify(mock, .methodWithCustomOptionalIntParameter(p: 2))
-        Verify(mock, .methodWithCustomOptionalIntParameter(p: 0))
+        Verify(mock, 1, .methodWithCustomOptionalIntParameter(p: .value(1)))
+        Verify(mock, .methodWithCustomOptionalIntParameter(p: .value(2)))
+        Verify(mock, .methodWithCustomOptionalIntParameter(p: .value(0)))
         Verify(mock, .methodWithCustomOptionalIntParameter(p: nil))
         Verify(mock, .never, .methodWithCustomOptionalIntParameter(p: .value(CustomInt.value(15))))
 
@@ -145,8 +145,8 @@ class ExpressibleByLiteralsTests: XCTestCase {
 
         Given(mock, .methodWithBool(p: .any, willReturn: 0))
         Given(mock, .methodWithBool(p: nil, willReturn: -1))
-        Given(mock, .methodWithBool(p: true, willReturn: 2))
-        Given(mock, .methodWithBool(p: false, willReturn: 1))
+        Given(mock, .methodWithBool(p: .value(true), willReturn: 2))
+        Given(mock, .methodWithBool(p: .value(false), willReturn: 1))
 
         XCTAssertEqual(mock.methodWithBool(p: nil), -1)
         XCTAssertEqual(mock.methodWithBool(p: true), 2)
@@ -154,8 +154,8 @@ class ExpressibleByLiteralsTests: XCTestCase {
 
         Verify(mock, 1, .methodWithBool(p: nil))
         Verify(mock, 1, .methodWithBool(p: .value(nil)))
-        Verify(mock, 1, .methodWithBool(p: true))
-        Verify(mock, 1, .methodWithBool(p: false))
+        Verify(mock, 1, .methodWithBool(p: .value(true)))
+        Verify(mock, 1, .methodWithBool(p: .value(false)))
         Verify(mock, 3, .methodWithBool(p: .any))
         Verify(mock, 2, .methodWithBool(p: .notNil))
     }
@@ -165,8 +165,8 @@ class ExpressibleByLiteralsTests: XCTestCase {
 
         Given(mock, .methodWithFloat(p: .any, willReturn: 0))
         Given(mock, .methodWithFloat(p: nil, willReturn: -1))
-        Given(mock, .methodWithFloat(p: 1.0, willReturn: 1))
-        Given(mock, .methodWithFloat(p: 2, willReturn: 2))
+        Given(mock, .methodWithFloat(p: .value(1.0), willReturn: 1))
+        Given(mock, .methodWithFloat(p: .value(2), willReturn: 2))
 
         XCTAssertEqual(mock.methodWithFloat(p: nil), -1)
         XCTAssertEqual(mock.methodWithFloat(p: 1.0000001), 0)
@@ -177,8 +177,8 @@ class ExpressibleByLiteralsTests: XCTestCase {
 
         Given(mock, .methodWithDouble(p: .any, willReturn: 0))
         Given(mock, .methodWithDouble(p: nil, willReturn: -1))
-        Given(mock, .methodWithDouble(p: 1.0, willReturn: 1))
-        Given(mock, .methodWithDouble(p: 2, willReturn: 2))
+        Given(mock, .methodWithDouble(p: .value(1.0), willReturn: 1))
+        Given(mock, .methodWithDouble(p: .value(2), willReturn: 2))
 
         XCTAssertEqual(mock.methodWithDouble(p: nil), -1)
         XCTAssertEqual(mock.methodWithDouble(p: 1.0000001), 0)
@@ -224,8 +224,8 @@ class ExpressibleByLiteralsTests: XCTestCase {
         Verify(mock, .once, .methodWithSetOfInt(p: [2,3,4]))
 
         Given(mock, .methodWithOptionalSetOfInt(p: .any, willReturn: 0))
-        Given(mock, .methodWithOptionalSetOfInt(p: [0,1,2], willReturn: 1))
-        Given(mock, .methodWithOptionalSetOfInt(p: [2,3,4], willReturn: 2))
+        Given(mock, .methodWithOptionalSetOfInt(p: .value([0,1,2]), willReturn: 1))
+        Given(mock, .methodWithOptionalSetOfInt(p: .value([2,3,4]), willReturn: 2))
         Given(mock, .methodWithOptionalSetOfInt(p: nil, willReturn: 3))
 
         XCTAssertEqual(mock.methodWithOptionalSetOfInt(p: [0,1]), 0)
@@ -234,9 +234,9 @@ class ExpressibleByLiteralsTests: XCTestCase {
         XCTAssertEqual(mock.methodWithOptionalSetOfInt(p: nil), 3)
 
         Verify(mock, 4, .methodWithOptionalSetOfInt(p: .any))
-        Verify(mock, .once, .methodWithOptionalSetOfInt(p: [0,1]))
-        Verify(mock, .once, .methodWithOptionalSetOfInt(p: [0,1,2]))
-        Verify(mock, .once, .methodWithOptionalSetOfInt(p: [2,3,4]))
+        Verify(mock, .once, .methodWithOptionalSetOfInt(p: .value([0,1])))
+        Verify(mock, .once, .methodWithOptionalSetOfInt(p: .value([0,1,2])))
+        Verify(mock, .once, .methodWithOptionalSetOfInt(p: .value([2,3,4])))
         Verify(mock, .once, .methodWithOptionalSetOfInt(p: nil))
     }
 

--- a/SwiftyMocky-Tests/Shared/Other/SimpleSequencingTests.swift
+++ b/SwiftyMocky-Tests/Shared/Other/SimpleSequencingTests.swift
@@ -154,7 +154,7 @@ class SimpleSequencingTests: XCTestCase {
 
         Given(mock, .simpleMehtodThatReturns(optionalParam: .any, willReturn: nil), .wrap)
         Given(mock, .simpleMehtodThatReturns(optionalParam: nil, willReturn: "a","b"), .drop)
-        Given(mock, .simpleMehtodThatReturns(optionalParam: "z", willReturn: "z","z","z"), .drop)
+        Given(mock, .simpleMehtodThatReturns(optionalParam: .value("z"), willReturn: "z","z","z"), .drop)
 
         XCTAssertEqual(mock.simpleMehtodThatReturns(optionalParam: nil), "a")
         XCTAssertEqual(mock.simpleMehtodThatReturns(optionalParam: "q"), nil)
@@ -171,7 +171,7 @@ class SimpleSequencingTests: XCTestCase {
     func test_mixed_policy_when_inverted() {
         let mock = SimpleProtocolWithMethodsMock(sequencing: .inWritingOrder)
 
-        Given(mock, .simpleMehtodThatReturns(optionalParam: "z", willReturn: "z","z","z"), .drop)
+        Given(mock, .simpleMehtodThatReturns(optionalParam: .value("z"), willReturn: "z","z","z"), .drop)
         Given(mock, .simpleMehtodThatReturns(optionalParam: nil, willReturn: "a","b"), .drop)
         Given(mock, .simpleMehtodThatReturns(optionalParam: .any, willReturn: nil), .wrap)
 

--- a/Templates/Helpers.swift
+++ b/Templates/Helpers.swift
@@ -36,7 +36,7 @@ class Helpers {
     }
     static func extractGenericsList(_ associatedTypes: [String]?) -> [String] {
         return associatedTypes?.flatMap {
-            split($0, byFirstOccurenceOf: " where ").0.replacingOccurrences(of: " ", with: "").characters.split(separator: ":").map(String.init).first
+            split($0, byFirstOccurenceOf: " where ").0.replacingOccurrences(of: " ", with: "").split(separator: ":").map(String.init).first
         }.map { "\($0)" } ?? []
     }
     static func extractGenericTypesModifier(_ associatedTypes: [String]?) -> String {
@@ -48,9 +48,9 @@ class Helpers {
         guard let all = associatedTypes else { return "" }
         let constraints = all.flatMap { t -> String? in
             let splitted = split(t, byFirstOccurenceOf: " where ")
-            let constraint = splitted.0.replacingOccurrences(of: " ", with: "").characters.split(separator: ":").map(String.init)
+            let constraint = splitted.0.replacingOccurrences(of: " ", with: "").split(separator: ":").map(String.init)
             guard constraint.count == 2 else { return nil }
-            let adopts = constraint[1].characters.split(separator: ",").map(String.init)
+            let adopts = constraint[1].split(separator: ",").map(String.init)
             var mapped = adopts.map { "\(constraint[0]): \($0)" }
             if !splitted.1.isEmpty {
                 mapped.append(splitted.1)

--- a/Templates/MethodWrapper.swift
+++ b/Templates/MethodWrapper.swift
@@ -641,7 +641,7 @@ class MethodWrapper {
         genPart.removeFirst()
         genPart.removeLast()
 
-        let parts = genPart.replacingOccurrences(of: " ", with: "").characters.split(separator: ",").map(String.init)
+        let parts = genPart.replacingOccurrences(of: " ", with: "").split(separator: ",").map(String.init)
         return parts.map { stripGenPart(part: $0) }
     }
 
@@ -656,7 +656,7 @@ class MethodWrapper {
         genPart.removeFirst()
         genPart.removeLast()
 
-        let parts = genPart.replacingOccurrences(of: " ", with: "").characters.split(separator: ",").map(String.init)
+        let parts = genPart.replacingOccurrences(of: " ", with: "").split(separator: ",").map(String.init)
         return parts.filter {
             let components = $0.components(separatedBy: ":")
             return (components.count == 2 || !filterSingle) && generics.contains(components[0])
@@ -678,7 +678,7 @@ class MethodWrapper {
     }
 
     private func stripGenPart(part: String) -> String {
-        return part.characters.split(separator: ":").map(String.init).first!
+        return part.split(separator: ":").map(String.init).first!
     }
 
     private func returnTypeStripped(_ method: SourceryRuntime.Method, type: Bool = false) -> String {


### PR DESCRIPTION
## Description
There were two issues that cropped up with use of Xcode 16:
1. Use of `.characters` on String types. This is now deprecated and we should be calling the functions directly on the Strings
2. The extensions to Optional for conformance to `ExpressibleByStringLiteral` etc.

For the first issue, simply removing `.characters` was enough.

For the second issue, I have just removed the Optional extensions. I think this is safe and will cause little inconvenience to the end user. The change they will need to make is moving from directly passing in `"some string"` as a parameter to type `Parameter<String?>` to `.value("some string")`. This is a direct result of [SE-0364](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md).

## Related issue
* Referencing https://github.com/MakeAWishFoundation/SwiftyMocky/issues/362